### PR TITLE
엔티티 모델 설정

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4F3177AB291BF70B0019BDFC /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177AA291BF70B0019BDFC /* RxSwift */; };
 		4F3177B0291BF7950019BDFC /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177AF291BF7950019BDFC /* SnapKit */; };
 		4F3177B5291BF7BC0019BDFC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177B4291BF7BC0019BDFC /* Kingfisher */; };
+		4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +28,7 @@
 		4F317785291BE4720019BDFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4F317788291BE4720019BDFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4F31778A291BE4720019BDFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListItem.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 		4F317793291BEB670019BDFC /* Entity */ = {
 			isa = PBXGroup;
 			children = (
+				4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 			files = (
 				4F317781291BE4710019BDFC /* ViewController.swift in Sources */,
 				4F31777D291BE4710019BDFC /* AppDelegate.swift in Sources */,
+				4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */,
 				4F31777F291BE4710019BDFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		4F3177B5291BF7BC0019BDFC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177B4291BF7BC0019BDFC /* Kingfisher */; };
 		4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */; };
 		4FEBFAAD291CF62E00E78139 /* DiaryDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */; };
+		4FEBFAAF291CF9F300E78139 /* MusicInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAAE291CF9F300E78139 /* MusicInfo.swift */; };
+		4FEBFAB1291CFB5500E78139 /* SHMediaItem+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAB0291CFB5500E78139 /* SHMediaItem+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +33,8 @@
 		4F31778A291BE4720019BDFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListItem.swift; sourceTree = "<group>"; };
 		4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDetail.swift; sourceTree = "<group>"; };
+		4FEBFAAE291CF9F300E78139 /* MusicInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicInfo.swift; sourceTree = "<group>"; };
+		4FEBFAB0291CFB5500E78139 /* SHMediaItem+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SHMediaItem+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,6 +118,7 @@
 			children = (
 				4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */,
 				4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */,
+				4FEBFAAE291CF9F300E78139 /* MusicInfo.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -138,6 +143,7 @@
 		4F317796291BEB900019BDFC /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				4FEBFAB0291CFB5500E78139 /* SHMediaItem+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -275,6 +281,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4FEBFAAD291CF62E00E78139 /* DiaryDetail.swift in Sources */,
+				4FEBFAB1291CFB5500E78139 /* SHMediaItem+.swift in Sources */,
+				4FEBFAAF291CF9F300E78139 /* MusicInfo.swift in Sources */,
 				4F317781291BE4710019BDFC /* ViewController.swift in Sources */,
 				4F31777D291BE4710019BDFC /* AppDelegate.swift in Sources */,
 				4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		4F3177B0291BF7950019BDFC /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177AF291BF7950019BDFC /* SnapKit */; };
 		4F3177B5291BF7BC0019BDFC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177B4291BF7BC0019BDFC /* Kingfisher */; };
 		4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */; };
+		4FEBFAAD291CF62E00E78139 /* DiaryDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,6 +30,7 @@
 		4F317788291BE4720019BDFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4F31778A291BE4720019BDFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListItem.swift; sourceTree = "<group>"; };
+		4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDetail.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */,
+				4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -271,6 +274,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4FEBFAAD291CF62E00E78139 /* DiaryDetail.swift in Sources */,
 				4F317781291BE4710019BDFC /* ViewController.swift in Sources */,
 				4F31777D291BE4710019BDFC /* AppDelegate.swift in Sources */,
 				4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */,

--- a/Segno/Segno/Entity/DiaryDetail.swift
+++ b/Segno/Segno/Entity/DiaryDetail.swift
@@ -5,12 +5,14 @@
 //  Created by Gordon Choi on 2022/11/10.
 //
 
+import CoreLocation
+
 struct DiaryDetail {
     let id: String
     let title: String
     let tags: [String]
     let imagePath: String
     let bodyText: String?
-    // 음악 정보
-    // 위치 정보
+    let musicInfo: MusicInfo?
+    let location: CLLocation?
 }

--- a/Segno/Segno/Entity/DiaryDetail.swift
+++ b/Segno/Segno/Entity/DiaryDetail.swift
@@ -1,0 +1,16 @@
+//
+//  DiaryDetail.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/10.
+//
+
+struct DiaryDetail {
+    let id: String
+    let title: String
+    let tags: [String]
+    let imagePath: String
+    let bodyText: String?
+    // 음악 정보
+    // 위치 정보
+}

--- a/Segno/Segno/Entity/DiaryListItem.swift
+++ b/Segno/Segno/Entity/DiaryListItem.swift
@@ -1,0 +1,12 @@
+//
+//  DiaryListItem.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/10.
+//
+
+struct DiaryListItem: Hashable {
+    let id: String
+    let title: String
+    let thumbnailPath: String
+}

--- a/Segno/Segno/Entity/MusicInfo.swift
+++ b/Segno/Segno/Entity/MusicInfo.swift
@@ -1,0 +1,28 @@
+//
+//  MusicInfo.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/10.
+//
+
+import Foundation
+import ShazamKit
+
+struct MusicInfo {
+    let title: String
+    let artist: String
+    let album: String
+    let imageURL: URL
+    
+    init?(mediaItem: SHMatchedMediaItem) {
+        guard let title = mediaItem.title,
+              let artist = mediaItem.artist,
+              let album = mediaItem.album,
+              let imageURL = mediaItem.artworkURL else { return nil }
+        
+        self.title = title
+        self.artist = artist
+        self.album = album
+        self.imageURL = imageURL
+    }
+}

--- a/Segno/Segno/Extension/SHMediaItem+.swift
+++ b/Segno/Segno/Extension/SHMediaItem+.swift
@@ -1,0 +1,18 @@
+//
+//  SHMediaItem+.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/10.
+//
+
+import ShazamKit
+
+extension SHMediaItemProperty {
+    static let album = SHMediaItemProperty("sh_albumName")
+}
+
+extension SHMediaItem {
+    var album: String? {
+        return self[.album] as? String
+    }
+}


### PR DESCRIPTION
11/10 #7 , #8 , #9 

## 작업한 내용
### 일기 리스트에 쓰일 정보를 위한 모델 작성
- id, 제목, 썸네일 주소 경로로 구성
### 일기 상세 항목에 쓰일 정보를 위한 모델 작성
- id, 제목, 태그, 사진주소, 내용, 음악 정보, 위치 정보로 구성
### 음악 정보에 관한 모델 작성
- 샤잠세션 검색 결과를 파싱해 구성
- Failable Initializer
- 제목, 아티스트, 앨범, 이미지 주소로 구성 

## 고민한 점 및 어려웠던 점
### CLLocation을 엔티티 모델에 넣어야 할까요?
- 위치 정보를 저장하기 위해 일단은 넣어 두었습니다.
- 향후 위도 경도만 Double로 뽑아 와서 넣어 둘 수 있을 것 같습니다.
### MusicInfo만 Path로 String 대신 URL이 들어가 있습니다.
- SHMediaItem에서 반환해주는 정보가 String이 아니라 URL이기 때문에 이렇게 해 주었습니다.
- 다만 다른 모델들에서는 URL 자체가 아니라 path를 String으로 저장하기 때문에, 통일성이 다소 결여되어 있습니다.
