### PR TITLE
DiaryCollectionViewController 화면 구성-2

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -31,16 +31,16 @@
 		666E6F85291CF4AD00CECD4B /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666E6F84291CF4AD00CECD4B /* MyPageCoordinator.swift */; };
 		666E6F87291CF4B400CECD4B /* DiaryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666E6F86291CF4B400CECD4B /* DiaryCoordinator.swift */; };
 		666E6F8A291CF82700CECD4B /* TabBarPageCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666E6F89291CF82700CECD4B /* TabBarPageCase.swift */; };
-		666E6F8C291CFAC200CECD4B /* DiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666E6F8B291CFAC200CECD4B /* DiaryViewController.swift */; };
+		666E6F8C291CFAC200CECD4B /* DiaryCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666E6F8B291CFAC200CECD4B /* DiaryCollectionViewController.swift */; };
 		666E6F8E291CFADD00CECD4B /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666E6F8D291CFADD00CECD4B /* MyPageViewController.swift */; };
-		7918380829233F7100BC6992 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7918380729233F7100BC6992 /* UIButton+.swift */; };
-    988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414AD2922235B007C9132 /* LocalUtilityRepository.swift */; };
-		988414D72923304F007C9132 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414D62923304F007C9132 /* KeychainError.swift */; };
 		791837FA292225C600BC6992 /* Cafe24Shiningstar.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 791837F7292225BF00BC6992 /* Cafe24Shiningstar.ttf */; };
 		791837FB292225C800BC6992 /* Cafe24Ssurround.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 791837F9292225BF00BC6992 /* Cafe24Ssurround.ttf */; };
 		791837FC292225CB00BC6992 /* Cafe24SsurroundAir.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 791837F8292225BF00BC6992 /* Cafe24SsurroundAir.ttf */; };
 		791837FF292225DC00BC6992 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791837FD292225DC00BC6992 /* UIColor+.swift */; };
 		79183800292225DC00BC6992 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791837FE292225DC00BC6992 /* UIFont+.swift */; };
+		7918380829233F7100BC6992 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7918380729233F7100BC6992 /* UIButton+.swift */; };
+		988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414AD2922235B007C9132 /* LocalUtilityRepository.swift */; };
+		988414D72923304F007C9132 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414D62923304F007C9132 /* KeychainError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -65,16 +65,16 @@
 		666E6F84291CF4AD00CECD4B /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		666E6F86291CF4B400CECD4B /* DiaryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCoordinator.swift; sourceTree = "<group>"; };
 		666E6F89291CF82700CECD4B /* TabBarPageCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPageCase.swift; sourceTree = "<group>"; };
-		666E6F8B291CFAC200CECD4B /* DiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryViewController.swift; sourceTree = "<group>"; };
+		666E6F8B291CFAC200CECD4B /* DiaryCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCollectionViewController.swift; sourceTree = "<group>"; };
 		666E6F8D291CFADD00CECD4B /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
-		7918380729233F7100BC6992 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
-		988414AD2922235B007C9132 /* LocalUtilityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUtilityRepository.swift; sourceTree = "<group>"; };
-		988414D62923304F007C9132 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
-    791837F7292225BF00BC6992 /* Cafe24Shiningstar.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Cafe24Shiningstar.ttf; sourceTree = "<group>"; };
+		791837F7292225BF00BC6992 /* Cafe24Shiningstar.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Cafe24Shiningstar.ttf; sourceTree = "<group>"; };
 		791837F8292225BF00BC6992 /* Cafe24SsurroundAir.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Cafe24SsurroundAir.ttf; sourceTree = "<group>"; };
 		791837F9292225BF00BC6992 /* Cafe24Ssurround.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Cafe24Ssurround.ttf; sourceTree = "<group>"; };
 		791837FD292225DC00BC6992 /* UIColor+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		791837FE292225DC00BC6992 /* UIFont+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		7918380729233F7100BC6992 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
+		988414AD2922235B007C9132 /* LocalUtilityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUtilityRepository.swift; sourceTree = "<group>"; };
+		988414D62923304F007C9132 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -212,7 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				4F317780291BE4710019BDFC /* LoginViewController.swift */,
-				666E6F8B291CFAC200CECD4B /* DiaryViewController.swift */,
+				666E6F8B291CFAC200CECD4B /* DiaryCollectionViewController.swift */,
 				666E6F8D291CFADD00CECD4B /* MyPageViewController.swift */,
 			);
 			path = ViewController;
@@ -371,7 +371,7 @@
 				666E6F81291CF49E00CECD4B /* LoginCoordinator.swift in Sources */,
 				666E6F85291CF4AD00CECD4B /* MyPageCoordinator.swift in Sources */,
 				666E6F7D291CF45600CECD4B /* Coordinator.swift in Sources */,
-				666E6F8C291CFAC200CECD4B /* DiaryViewController.swift in Sources */,
+				666E6F8C291CFAC200CECD4B /* DiaryCollectionViewController.swift in Sources */,
 				666E6F8A291CF82700CECD4B /* TabBarPageCase.swift in Sources */,
 				79183800292225DC00BC6992 /* UIFont+.swift in Sources */,
 				666E6F83291CF4A600CECD4B /* TabBarCoordinator.swift in Sources */,
@@ -381,7 +381,6 @@
 				791837FF292225DC00BC6992 /* UIColor+.swift in Sources */,
 				666E6F7F291CF46800CECD4B /* AppCoordinator.swift in Sources */,
 				988414D72923304F007C9132 /* KeychainError.swift in Sources */,
-				4F31777D291BE4710019BDFC /* AppDelegate.swift in Sources */,
 				666E6F87291CF4B400CECD4B /* DiaryCoordinator.swift in Sources */,
 				4F31777F291BE4710019BDFC /* SceneDelegate.swift in Sources */,
 			);

--- a/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
@@ -16,8 +16,7 @@ final class DiaryCoordinator: Coordinator {
     }
     
     func start() {
-        // TODO: 추후에 올바른 layout 보내주기
-        let vc = DiaryCollectionViewController(layout: UICollectionViewLayout())
+        let vc = DiaryCollectionViewController()
         self.navigationController.pushViewController(vc, animated: true)
     }
 }

--- a/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
@@ -17,7 +17,7 @@ final class DiaryCoordinator: Coordinator {
     
     func start() {
         // TODO: 추후에 올바른 layout 보내주기
-        let vc = DiaryViewController(layout: UICollectionViewLayout())
+        let vc = DiaryCollectionViewController(layout: UICollectionViewLayout())
         self.navigationController.pushViewController(vc, animated: true)
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -9,18 +9,8 @@ import UIKit
 import SnapKit
 
 final class DiaryCollectionViewController: UIViewController {
-    // TODO: 추후에 viewModel도 가져와서 연결하기
-    private let layout: UICollectionViewLayout
-    
     private enum Metric {
-        static let spacingBetweenButtons: CGFloat = 20
         static let inset: CGFloat = 20
-     
-        static let titleHeight: CGFloat = 100
-        static let titleOffset: CGFloat = 200
-        static let subTitleHeight: CGFloat = 50
-        static let buttonHeight: CGFloat = 50
-        static let buttonRadius: CGFloat = 20
     }
     
     lazy var searchBar: UISearchBar = {
@@ -28,26 +18,15 @@ final class DiaryCollectionViewController: UIViewController {
         bar.placeholder = "Search Bar Test!"
         bar.setImage(UIImage(named: "search_back"), for: .search, state: .normal)
         bar.setImage(UIImage(named: "search_cancel"), for: .clear, state: .normal)
-        bar.translatesAutoresizingMaskIntoConstraints = false
         return bar
     }()
     
     lazy var diaryCollectionView: UICollectionView = {
+        let layout = makeCollectionViewLayout()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .appColor(.color1)
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
-    
-    init(layout: UICollectionViewLayout) {
-        self.layout = layout
-        
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -78,5 +57,18 @@ final class DiaryCollectionViewController: UIViewController {
             make.top.equalTo(searchBar.snp.bottom)
             make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
+    }
+}
+
+extension DiaryCollectionViewController {
+    func makeCollectionViewLayout() -> UICollectionViewFlowLayout {
+        let layout = UICollectionViewFlowLayout()
+        let cellWidth: CGFloat = UIScreen.main.bounds.width / 2 - 1
+        
+        layout.itemSize = CGSize(width: cellWidth, height: cellWidth)
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 1
+        layout.minimumInteritemSpacing = 1
+        return layout
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -22,8 +22,7 @@ final class DiaryCollectionViewController: UIViewController {
     
     lazy var diaryCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        // TODO: 추후에 .black 같은 Magic Number 삭제
-        collectionView.backgroundColor = .black
+        collectionView.backgroundColor = .appColor(.color1)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
@@ -45,8 +44,7 @@ final class DiaryCollectionViewController: UIViewController {
     }
 
     private func setupView() {
-        // TODO: 추후에 .white 같은 Magic Number 삭제
-        view.backgroundColor = .white
+        view.backgroundColor = .appColor(.background)
         view.addSubview(searchBar)
         
         // TODO: 추후에 SnapKit 적용하여 레이아웃 맞추기

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -6,10 +6,22 @@
 //
 
 import UIKit
+import SnapKit
 
 final class DiaryCollectionViewController: UIViewController {
     // TODO: 추후에 viewModel도 가져와서 연결하기
     private let layout: UICollectionViewLayout
+    
+    private enum Metric {
+        static let spacingBetweenButtons: CGFloat = 20
+        static let inset: CGFloat = 20
+     
+        static let titleHeight: CGFloat = 100
+        static let titleOffset: CGFloat = 200
+        static let subTitleHeight: CGFloat = 50
+        static let buttonHeight: CGFloat = 50
+        static let buttonRadius: CGFloat = 20
+    }
     
     lazy var searchBar: UISearchBar = {
         let bar = UISearchBar()
@@ -41,27 +53,30 @@ final class DiaryCollectionViewController: UIViewController {
         super.viewDidLoad()
         
         setupView()
+        setupLayout()
     }
-
+    
     private func setupView() {
         view.backgroundColor = .appColor(.background)
-        view.addSubview(searchBar)
+    }
+
+    private func setupLayout() {
+        [searchBar, diaryCollectionView].forEach {
+            view.addSubview($0)
+            
+            $0.snp.makeConstraints { make in
+                make.width.equalToSuperview().inset(Metric.inset)
+                make.centerX.equalTo(view.snp.centerX)
+            }
+        }
         
-        // TODO: 추후에 SnapKit 적용하여 레이아웃 맞추기
-        NSLayoutConstraint.activate([
-            searchBar.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            searchBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
+        searchBar.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+        }
         
-        view.addSubview(diaryCollectionView)
-        
-        NSLayoutConstraint.activate([
-            diaryCollectionView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
-            diaryCollectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            diaryCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            diaryCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
+        diaryCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(searchBar.snp.bottom)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DiaryViewController: UIViewController {
+final class DiaryCollectionViewController: UIViewController {
     // TODO: 추후에 viewModel도 가져와서 연결하기
     private let layout: UICollectionViewLayout
     


### PR DESCRIPTION
11/15 #18 #34

## 작업한 내용
### DiaryCollectionViewController 화면 구성
- 파일명 및 클래스 명 수정(DiaryViewController -> DiaryCollectionViewController)
- 색상과 관련된 magic number 제거 및 appColor 적용
- AutoLayout 대신 SnapKit으로 적용
### 한 행당 2개씩 일기 내용을  표시하는 컬렉션 뷰 구성
- CollectionViewFlowLayout을 Coordinator가 아닌 ViewController에서 만들도록 수정

## 고민한 점 및 어려웠던 점
### 구조에 대한 고민
- CollectionViewFlowLayout을 Coordinator가 아니라 ViewController에서 만드는게 옳다고 생각하였습니다.
- Coordinator의 경우 단순히 ViewController를 띄워줄 뿐, 해당 뷰 컨트롤러의 속성인 Layout을 만드는 역할을 하는 것은 바람직하지 않다고 생각했습니다.
