### PR TITLE
로그인 레포지토리 작성

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4F3177AB291BF70B0019BDFC /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177AA291BF70B0019BDFC /* RxSwift */; };
 		4F3177B0291BF7950019BDFC /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177AF291BF7950019BDFC /* SnapKit */; };
 		4F3177B5291BF7BC0019BDFC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177B4291BF7BC0019BDFC /* Kingfisher */; };
+		4F4E0D3E2924B925005ABA8F /* LoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D3D2924B925005ABA8F /* LoginRepository.swift */; };
 		4F9A001B292227D7007D9057 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001A292227D7007D9057 /* NetworkManager.swift */; };
 		4F9A001D29222B1B007D9057 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001C29222B1B007D9057 /* Endpoint.swift */; };
 		4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001E29222C97007D9057 /* NetworkError.swift */; };
@@ -57,6 +58,7 @@
 		4F317785291BE4720019BDFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4F317788291BE4720019BDFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4F31778A291BE4720019BDFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4F4E0D3D2924B925005ABA8F /* LoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRepository.swift; sourceTree = "<group>"; };
 		4F9A001A292227D7007D9057 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4F9A001C29222B1B007D9057 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		4F9A001E29222C97007D9057 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				4FA3242429235FF800DB04D5 /* DTO */,
 				988414AD2922235B007C9132 /* LocalUtilityRepository.swift */,
 				4FA32427292363AA00DB04D5 /* DiaryRepository.swift */,
+				4F4E0D3D2924B925005ABA8F /* LoginRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4F4E0D3E2924B925005ABA8F /* LoginRepository.swift in Sources */,
 				4F9A00212922338E007D9057 /* AppDelegate.swift in Sources */,
 				4F9A00202922337F007D9057 /* LoginViewController.swift in Sources */,
 				4F9A001B292227D7007D9057 /* NetworkManager.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		4F3177B5291BF7BC0019BDFC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177B4291BF7BC0019BDFC /* Kingfisher */; };
 		4F4E0D3E2924B925005ABA8F /* LoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D3D2924B925005ABA8F /* LoginRepository.swift */; };
 		4F4E0D74292521D0005ABA8F /* UserInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */; };
+		4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */; };
+		4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D78292522B7005ABA8F /* BaseURL.swift */; };
 		4F9A001B292227D7007D9057 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001A292227D7007D9057 /* NetworkManager.swift */; };
 		4F9A001D29222B1B007D9057 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001C29222B1B007D9057 /* Endpoint.swift */; };
 		4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001E29222C97007D9057 /* NetworkError.swift */; };
@@ -61,6 +63,8 @@
 		4F31778A291BE4720019BDFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4F4E0D3D2924B925005ABA8F /* LoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRepository.swift; sourceTree = "<group>"; };
 		4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoDTO.swift; sourceTree = "<group>"; };
+		4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEndpoint.swift; sourceTree = "<group>"; };
+		4F4E0D78292522B7005ABA8F /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
 		4F9A001A292227D7007D9057 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4F9A001C29222B1B007D9057 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		4F9A001E29222C97007D9057 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -259,6 +263,7 @@
 		4F31779F291BF1780019BDFC /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				4F4E0D77292522AC005ABA8F /* Namespaces */,
 				4FA324292923646200DB04D5 /* Endpoints */,
 				4F9A001A292227D7007D9057 /* NetworkManager.swift */,
 				4F9A001C29222B1B007D9057 /* Endpoint.swift */,
@@ -278,6 +283,14 @@
 			path = Repository;
 			sourceTree = "<group>";
 		};
+		4F4E0D77292522AC005ABA8F /* Namespaces */ = {
+			isa = PBXGroup;
+			children = (
+				4F4E0D78292522B7005ABA8F /* BaseURL.swift */,
+			);
+			path = Namespaces;
+			sourceTree = "<group>";
+		};
 		4FA3242429235FF800DB04D5 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
@@ -291,6 +304,7 @@
 			isa = PBXGroup;
 			children = (
 				4FA3242A2923646F00DB04D5 /* DiaryListItemEndpoint.swift */,
+				4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -413,6 +427,7 @@
 				7918380829233F7100BC6992 /* UIButton+.swift in Sources */,
 				666E6F81291CF49E00CECD4B /* LoginCoordinator.swift in Sources */,
 				666E6F85291CF4AD00CECD4B /* MyPageCoordinator.swift in Sources */,
+				4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */,
 				988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */,
 				666E6F7D291CF45600CECD4B /* Coordinator.swift in Sources */,
 				666E6F8C291CFAC200CECD4B /* DiaryCollectionViewController.swift in Sources */,
@@ -426,6 +441,7 @@
 				791837FF292225DC00BC6992 /* UIColor+.swift in Sources */,
 				666E6F7F291CF46800CECD4B /* AppCoordinator.swift in Sources */,
 				988414D72923304F007C9132 /* KeychainError.swift in Sources */,
+				4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */,
 				4FA324262923600C00DB04D5 /* DiaryListDTO.swift in Sources */,
 				666E6F87291CF4B400CECD4B /* DiaryCoordinator.swift in Sources */,
 				4F31777F291BE4710019BDFC /* SceneDelegate.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		4F4E0D74292521D0005ABA8F /* UserInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */; };
 		4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */; };
 		4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D78292522B7005ABA8F /* BaseURL.swift */; };
+		4F4E0D7B29252526005ABA8F /* TokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7A29252526005ABA8F /* TokenDTO.swift */; };
 		4F9A001B292227D7007D9057 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001A292227D7007D9057 /* NetworkManager.swift */; };
 		4F9A001D29222B1B007D9057 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001C29222B1B007D9057 /* Endpoint.swift */; };
 		4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001E29222C97007D9057 /* NetworkError.swift */; };
@@ -65,6 +66,7 @@
 		4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoDTO.swift; sourceTree = "<group>"; };
 		4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEndpoint.swift; sourceTree = "<group>"; };
 		4F4E0D78292522B7005ABA8F /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
+		4F4E0D7A29252526005ABA8F /* TokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDTO.swift; sourceTree = "<group>"; };
 		4F9A001A292227D7007D9057 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4F9A001C29222B1B007D9057 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		4F9A001E29222C97007D9057 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -296,6 +298,7 @@
 			children = (
 				4FA324252923600C00DB04D5 /* DiaryListDTO.swift */,
 				4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */,
+				4F4E0D7A29252526005ABA8F /* TokenDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -425,6 +428,7 @@
 				4FEBFAAF291CF9F300E78139 /* MusicInfo.swift in Sources */,
 				4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */,
 				7918380829233F7100BC6992 /* UIButton+.swift in Sources */,
+				4F4E0D7B29252526005ABA8F /* TokenDTO.swift in Sources */,
 				666E6F81291CF49E00CECD4B /* LoginCoordinator.swift in Sources */,
 				666E6F85291CF4AD00CECD4B /* MyPageCoordinator.swift in Sources */,
 				4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		4F3177B0291BF7950019BDFC /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177AF291BF7950019BDFC /* SnapKit */; };
 		4F3177B5291BF7BC0019BDFC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3177B4291BF7BC0019BDFC /* Kingfisher */; };
 		4F4E0D3E2924B925005ABA8F /* LoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D3D2924B925005ABA8F /* LoginRepository.swift */; };
+		4F4E0D74292521D0005ABA8F /* UserInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */; };
 		4F9A001B292227D7007D9057 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001A292227D7007D9057 /* NetworkManager.swift */; };
 		4F9A001D29222B1B007D9057 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001C29222B1B007D9057 /* Endpoint.swift */; };
 		4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001E29222C97007D9057 /* NetworkError.swift */; };
@@ -59,6 +60,7 @@
 		4F317788291BE4720019BDFC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4F31778A291BE4720019BDFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4F4E0D3D2924B925005ABA8F /* LoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRepository.swift; sourceTree = "<group>"; };
+		4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoDTO.swift; sourceTree = "<group>"; };
 		4F9A001A292227D7007D9057 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4F9A001C29222B1B007D9057 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		4F9A001E29222C97007D9057 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 			isa = PBXGroup;
 			children = (
 				4FA324252923600C00DB04D5 /* DiaryListDTO.swift */,
+				4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -426,6 +429,7 @@
 				4FA324262923600C00DB04D5 /* DiaryListDTO.swift in Sources */,
 				666E6F87291CF4B400CECD4B /* DiaryCoordinator.swift in Sources */,
 				4F31777F291BE4710019BDFC /* SceneDelegate.swift in Sources */,
+				4F4E0D74292521D0005ABA8F /* UserInfoDTO.swift in Sources */,
 				4FA32428292363AB00DB04D5 /* DiaryRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Segno/Segno/Data/Network/Endpoints/DiaryListItemEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/DiaryListItemEndpoint.swift
@@ -12,7 +12,7 @@ enum DiaryListItemEndpoint: Endpoint {
     case item
     
     var baseURL: URL? {
-        return URL(string: "https://baero.me")
+        return URL(string: BaseURL.urlString)
     }
     
     var httpMethod: HTTPMethod {

--- a/Segno/Segno/Data/Network/Endpoints/LoginEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/LoginEndpoint.swift
@@ -1,0 +1,31 @@
+//
+//  LoginEndpoint.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/16.
+//
+
+import Foundation
+
+enum LoginEndpoint: Endpoint {
+    case apple(String)
+    
+    var baseURL: URL? {
+        return URL(string: BaseURL.urlString)
+    }
+    
+    var httpMethod: HTTPMethod {
+        return .POST
+    }
+    
+    var path: String {
+        return "login"
+    }
+    
+    var parameters: HTTPRequestParameter? {
+        switch self {
+        case .apple(let email):
+            return HTTPRequestParameter.body(["email": email, "oauthType": "apple"])
+        }
+    }
+}

--- a/Segno/Segno/Data/Network/Namespaces/BaseURL.swift
+++ b/Segno/Segno/Data/Network/Namespaces/BaseURL.swift
@@ -1,0 +1,10 @@
+//
+//  BaseURL.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/16.
+//
+
+enum BaseURL {
+    static let urlString = "https://baero.me"
+}

--- a/Segno/Segno/Data/Repository/DTO/TokenDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/TokenDTO.swift
@@ -1,0 +1,10 @@
+//
+//  TokenDTO.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/16.
+//
+
+struct TokenDTO: Decodable {
+    let token: String
+}

--- a/Segno/Segno/Data/Repository/DTO/UserInfoDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/UserInfoDTO.swift
@@ -1,0 +1,11 @@
+//
+//  UserInfoDTO.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/16.
+//
+
+struct UserInfoDTO: Codable {
+    let id: String
+    let username: String
+}

--- a/Segno/Segno/Data/Repository/LoginRepository.swift
+++ b/Segno/Segno/Data/Repository/LoginRepository.swift
@@ -8,17 +8,12 @@
 import RxSwift
 
 protocol LoginRepository {
-    func sendOAuthRequest()
-    func sendLoginRequest()
+    func sendLoginRequest(id: String)
     func sendLogoutRequest()
 }
 
 final class LoginRepositoryImpl: LoginRepository {
-    func sendOAuthRequest() {
-        
-    }
-    
-    func sendLoginRequest() {
+    func sendLoginRequest(id: String) {
         
     }
     

--- a/Segno/Segno/Data/Repository/LoginRepository.swift
+++ b/Segno/Segno/Data/Repository/LoginRepository.swift
@@ -5,16 +5,22 @@
 //  Created by Gordon Choi on 2022/11/16.
 //
 
+import Foundation
 import RxSwift
 
 protocol LoginRepository {
-    func sendLoginRequest(id: String)
+    func sendLoginRequest(email: String) -> Single<TokenDTO>
     func sendLogoutRequest()
 }
 
 final class LoginRepositoryImpl: LoginRepository {
-    func sendLoginRequest(id: String) {
-        
+    func sendLoginRequest(email: String) -> Single<TokenDTO> {
+        let endpoint = LoginEndpoint.apple(email)
+        return NetworkManager.shared.call(endpoint)
+            .map {
+                let tokenDTO = try JSONDecoder().decode(TokenDTO.self, from: $0)
+                return tokenDTO
+            }
     }
     
     func sendLogoutRequest() {

--- a/Segno/Segno/Data/Repository/LoginRepository.swift
+++ b/Segno/Segno/Data/Repository/LoginRepository.swift
@@ -1,0 +1,28 @@
+//
+//  LoginRepository.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/16.
+//
+
+import RxSwift
+
+protocol LoginRepository {
+    func sendOAuthRequest()
+    func sendLoginRequest()
+    func sendLogoutRequest()
+}
+
+final class LoginRepositoryImpl: LoginRepository {
+    func sendOAuthRequest() {
+        
+    }
+    
+    func sendLoginRequest() {
+        
+    }
+    
+    func sendLogoutRequest() {
+        
+    }
+}


### PR DESCRIPTION
11/16 #46 #47 #48 

## 작업한 내용
### 로그인 레포지토리를 작성했습니다.
- OAuth 인증 후 이메일과 회사 정보를 서버에 전송해 자체 서버 로그인을 요청합니다.
- 서버에서 온 응답을 토큰(이후 이름을 포함한 유저 정보로 수정될 가능성이 높음) DTO로 디코딩한 후 발신합니다.
### 로그인을 위한 엔드포인트를 작성했습니다.
- 회사 정보와 사용한 이메일을 사용하게끔 작성했습니다.
- 추후 다른 방식으로 변경되면, 변경의 소지가 있습니다.

## 고민한 점 및 어려웠던 점
### OAuth 로그인 처리를 레포지토리에서 해 주어야 할지 고민했습니다.
- 각고의 고민 끝에, View Controller에서 다루는 것이 적합하다고 생각해 레포지토리에서는 다루지 않았습니다.
- Wiki의 "주간 Dal Segno"에 상세히 기술할 예정입니다.
### 서버로부터의 응답에 이름을 포함시키는 것을 요구할지, DTO를 그에 맞게 바꿔야 할지 고민했습니다.
- 로그인했을 때 사용자가 자신의 닉네임을 볼 수 있어야 한다고 판단했습니다. 그래서 로그인했을 때 서버로부터 이름을 받아올 수 있으면 좋겠다고 생각했습니다. 향후 닉네임 변경 기능이 추가될 것을 감안했습니다.
- 일단 현재의 작동을 위해 토큰만을 가져오는 DTO를 만들었고, 명세가 바뀌면 유연하게 대응할 수 있는 유저 정보 DTO도 구현해 두었습니다. 향후 서버 명세의 확정에 따라 한 가지를 삭제할 예정입니다.
