### PR TITLE
LoginUseCase 작성

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		79183800292225DC00BC6992 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791837FE292225DC00BC6992 /* UIFont+.swift */; };
 		7918380829233F7100BC6992 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7918380729233F7100BC6992 /* UIButton+.swift */; };
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
+		9841D6172925FACC00318EA9 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9841D6162925FACC00318EA9 /* LoginUseCase.swift */; };
 		988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414AD2922235B007C9132 /* LocalUtilityRepository.swift */; };
 		988414D72923304F007C9132 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414D62923304F007C9132 /* KeychainError.swift */; };
 		988414D929235345007C9132 /* DiaryCollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414D829235345007C9132 /* DiaryCollectionViewModel.swift */; };
@@ -95,6 +96,7 @@
 		791837FE292225DC00BC6992 /* UIFont+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		7918380729233F7100BC6992 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
+		9841D6162925FACC00318EA9 /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
 		988414AD2922235B007C9132 /* LocalUtilityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUtilityRepository.swift; sourceTree = "<group>"; };
 		988414D62923304F007C9132 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
 		988414D829235345007C9132 /* DiaryCollectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCollectionViewModel.swift; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 		4F317797291BEE3D0019BDFC /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				9841D6162925FACC00318EA9 /* LoginUseCase.swift */,
 				988414DA2923606B007C9132 /* DiaryListUseCase.swift */,
 			);
 			path = UseCase;
@@ -425,6 +428,7 @@
 				982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */,
 				4F9A001B292227D7007D9057 /* NetworkManager.swift in Sources */,
 				66F0D7EA2923864E0074872E /* DiaryCell.swift in Sources */,
+				9841D6172925FACC00318EA9 /* LoginUseCase.swift in Sources */,
 				4FEBFAAD291CF62E00E78139 /* DiaryDetail.swift in Sources */,
 				4FEBFAB1291CFB5500E78139 /* SHMediaItem+.swift in Sources */,
 				988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */,
@@ -593,7 +597,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = H5UNW2D34P;
+				DEVELOPMENT_TEAM = PN5JFN8NYT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -621,7 +625,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = H5UNW2D34P;
+				DEVELOPMENT_TEAM = PN5JFN8NYT;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Segno/Segno/Domain/UseCase/LoginUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/LoginUseCase.swift
@@ -1,0 +1,47 @@
+//
+//  LoginUseCse.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/17.
+//
+
+import RxSwift
+
+protocol LoginUseCase {
+    func sendLoginRequest(email: String) -> Single<Bool>
+}
+
+final class LoginUseCaseImpl: LoginUseCase {
+
+    private enum Metric {
+        static let serverToken = "serverToken"
+    }
+
+    let repository: LoginRepository
+    let localUtilityRepository: LocalUtilityRepository
+    private let disposeBag = DisposeBag()
+
+    init(repository: LoginRepository = LoginRepositoryImpl(),
+         localUtilityRepository: LocalUtilityRepository = LocalUtilityRepositoryImpl()) {
+        self.repository = repository
+        self.localUtilityRepository = localUtilityRepository
+    }
+
+    func sendLoginRequest(email: String) -> Single<Bool> {
+        return Single.create { single in
+            self.repository.sendLoginRequest(email: email)
+                .subscribe(onSuccess: { token in
+                    print("서버에서 받아온 토큰 : ", token)
+                    single(.success(true))
+                    // TODO: UserInformation Entity를 생성하여
+                    
+                    // TODO: LocalUtilityRepository에 전달한다.
+                }, onFailure: { error in
+                    single(.failure(error))
+                })
+                .disposed(by: self.disposeBag)
+
+            return Disposables.create()
+        }
+    }
+}


### PR DESCRIPTION
11/17 #51 #53 

## 작업한 내용
### 로그인 요청을 Repository로 보내고 그 결과를 뷰모델로 리턴하는 메서드를 작성했습니다.
- sendLoginRequest(email: ) 메서드를 통해 TokenDTO를 정상적으로 받으면 .success(true)를, 실패한 경우 .failure(error)를 ViewModel로 리턴합니다.

## 고민한 점 및 어려웠던 점
### 커밋을 쪼개야 할 지 고민했습니다.
- 두 가지 이슈를 한 번에 처리하여 고민된 사항이나, 두 이슈를 분리하기가 사실상 어렵다고 생각되어 한 번에 커밋하였습니다.