### PR TITLE
로그인 플로우 확립

### DIFF
--- a/Segno/Segno/Application/AppCoordinator.swift
+++ b/Segno/Segno/Application/AppCoordinator.swift
@@ -18,12 +18,28 @@ final class AppCoordinator: Coordinator {
     
     func start() {
         // TODO: login이 안되어있으면 LoginCoordinator 실행
+        startLoginCoordinator()
+        // TODO: login이 되어있으면 TabBarCoordinator 실행
+    }
+    
+    func startLoginCoordinator() {
         let loginCoordinator = LoginCoordinator(navigationController)
+        loginCoordinator.delegate = self
         loginCoordinator.start()
         childCoordinators.append(loginCoordinator)
-        // TODO: login이 되어있으면 TabBarCoordinator 실행
-//        let tabBarCoordinator = TabBarCoordinator(navigationController)
-//        tabBarCoordinator.start()
-//        childCoordinators.append(tabBarCoordinator)
+    }
+    
+    func startTabBarCoordinator() {
+        let tabBarCoordinator = TabBarCoordinator(navigationController)
+        tabBarCoordinator.start()
+        childCoordinators.append(tabBarCoordinator)
+    }
+}
+
+extension AppCoordinator: LoginCoordinatorDelegate {
+    func loginDidSucceed(_ coordinator: LoginCoordinator) {
+        childCoordinators = childCoordinators.filter { $0 === coordinator }
+        
+        startTabBarCoordinator()
     }
 }

--- a/Segno/Segno/Application/AppDelegate.swift
+++ b/Segno/Segno/Application/AppDelegate.swift
@@ -5,8 +5,9 @@
 //  Created by Gordon Choi on 2022/11/09.
 //
 
-import UIKit
 import AuthenticationServices
+import UIKit
+
 import GoogleSignIn
 
 @main

--- a/Segno/Segno/Application/AppDelegate.swift
+++ b/Segno/Segno/Application/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
-        // AppleLogin 기록에 관한 코드
+        // AppleLogin 기록에 관한 코드 - 향후 자동 로그인 지원에 사용
 //        let appleIDProvider = ASAuthorizationAppleIDProvider()
 //        appleIDProvider.getCredentialState(forUserID: "001342.777c9aea9ed046a2a75c03f01748113d.0743") { (credentialState, error) in
 //            switch credentialState {

--- a/Segno/Segno/Application/AppDelegate.swift
+++ b/Segno/Segno/Application/AppDelegate.swift
@@ -24,22 +24,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         // AppleLogin 기록에 관한 코드
-        let appleIDProvider = ASAuthorizationAppleIDProvider()
-        appleIDProvider.getCredentialState(forUserID: "000128.42c946e8142749b08b8e429b59b19730.0733") { (credentialState, error) in
-            switch credentialState {
-            case .authorized:
-                // The Apple ID credential is valid.
-                print("해당 ID는 연동되어있습니다.")
-            case .revoked:
-                // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
-                print("해당 ID는 연동되어있지않습니다.")
-            case .notFound:
-                // The Apple ID credential is either was not found, so show the sign-in UI.
-                print("해당 ID를 찾을 수 없습니다.")
-            default:
-                break
-            }
-        }
+//        let appleIDProvider = ASAuthorizationAppleIDProvider()
+//        appleIDProvider.getCredentialState(forUserID: "001342.777c9aea9ed046a2a75c03f01748113d.0743") { (credentialState, error) in
+//            switch credentialState {
+//            case .authorized:
+//                // The Apple ID credential is valid.
+//                print("해당 ID는 연동되어있습니다.")
+//            case .revoked:
+//                // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
+//                print("해당 ID는 연동되어있지않습니다.")
+//            case .notFound:
+//                // The Apple ID credential is either was not found, so show the sign-in UI.
+//                print("해당 ID를 찾을 수 없습니다.")
+//            default:
+//                break
+//            }
+//        }
         
         NotificationCenter.default.addObserver(forName: ASAuthorizationAppleIDProvider.credentialRevokedNotification, object: nil, queue: nil) { (Notification) in
             print("Revoked Notification")

--- a/Segno/Segno/Data/Network/Endpoints/LoginEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/LoginEndpoint.swift
@@ -12,7 +12,8 @@ enum LoginEndpoint: Endpoint {
     case google(String)
     
     var baseURL: URL? {
-        return URL(string: BaseURL.urlString)
+        return URL(string: BaseURL.urlString)?
+            .appendingPathComponent("auth")
     }
     
     var httpMethod: HTTPMethod {

--- a/Segno/Segno/Data/Network/Endpoints/LoginEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/LoginEndpoint.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum LoginEndpoint: Endpoint {
     case apple(String)
+    case google(String)
     
     var baseURL: URL? {
         return URL(string: BaseURL.urlString)
@@ -26,6 +27,8 @@ enum LoginEndpoint: Endpoint {
         switch self {
         case .apple(let email):
             return HTTPRequestParameter.body(["email": email, "oauthType": "apple"])
+        case .google(let email):
+            return HTTPRequestParameter.body(["email": email, "oauthType": "google"])
         }
     }
 }

--- a/Segno/Segno/Data/Network/NetworkManager.swift
+++ b/Segno/Segno/Data/Network/NetworkManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import RxSwift
 
 struct NetworkManager {

--- a/Segno/Segno/Data/Repository/DTO/TokenDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/TokenDTO.swift
@@ -6,5 +6,5 @@
 //
 
 struct TokenDTO: Decodable {
-    let token: String
+    let token: String?
 }

--- a/Segno/Segno/Data/Repository/DiaryRepository.swift
+++ b/Segno/Segno/Data/Repository/DiaryRepository.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import RxSwift
 
 protocol DiaryRepository {

--- a/Segno/Segno/Data/Repository/LocalUtilityRepository.swift
+++ b/Segno/Segno/Data/Repository/LocalUtilityRepository.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import RxSwift
 
 protocol LocalUtilityRepository {

--- a/Segno/Segno/Data/Repository/LoginRepository.swift
+++ b/Segno/Segno/Data/Repository/LoginRepository.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import RxSwift
 
 protocol LoginRepository {

--- a/Segno/Segno/Data/Repository/LoginRepository.swift
+++ b/Segno/Segno/Data/Repository/LoginRepository.swift
@@ -20,6 +20,7 @@ final class LoginRepositoryImpl: LoginRepository {
         return NetworkManager.shared.call(endpoint)
             .map {
                 let tokenDTO = try JSONDecoder().decode(TokenDTO.self, from: $0)
+                print(tokenDTO)
                 return tokenDTO
             }
     }

--- a/Segno/Segno/Domain/UseCase/LoginUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/LoginUseCase.swift
@@ -8,7 +8,7 @@
 import RxSwift
 
 protocol LoginUseCase {
-    func sendLoginRequest(email: String) -> Single<Bool>
+    func sendLoginRequest(email: String) -> Single<String>
 }
 
 final class LoginUseCaseImpl: LoginUseCase {
@@ -27,21 +27,28 @@ final class LoginUseCaseImpl: LoginUseCase {
         self.localUtilityRepository = localUtilityRepository
     }
 
-    func sendLoginRequest(email: String) -> Single<Bool> {
-        return Single.create { single in
-            self.repository.sendLoginRequest(email: email)
-                .subscribe(onSuccess: { token in
-                    print("서버에서 받아온 토큰 : ", token)
-                    single(.success(true))
-                    // TODO: UserInformation Entity를 생성하여
-                    
-                    // TODO: LocalUtilityRepository에 전달한다.
-                }, onFailure: { error in
-                    single(.failure(error))
-                })
-                .disposed(by: self.disposeBag)
-
-            return Disposables.create()
-        }
+    func sendLoginRequest(email: String) -> Single<String> {
+//        return Single.create { single in
+//            self.repository.sendLoginRequest(email: email)
+//                .subscribe(onSuccess: { token in
+//                    print("서버에서 받아온 토큰 : ", token)
+//                    single(.success(true))
+//                    // TODO: UserInformation Entity를 생성하여
+//
+//                    // TODO: LocalUtilityRepository에 전달한다.
+//                }, onFailure: { error in
+//                    single(.failure(error))
+//                })
+//                .disposed(by: self.disposeBag)
+//
+//            return Disposables.create()
+//        }
+        
+        return repository.sendLoginRequest(email: email)
+            .map {
+                let tokenString = $0.token
+                print(tokenString)
+                return tokenString
+            }
     }
 }

--- a/Segno/Segno/Domain/UseCase/LoginUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/LoginUseCase.swift
@@ -46,7 +46,7 @@ final class LoginUseCaseImpl: LoginUseCase {
         
         return repository.sendLoginRequest(email: email)
             .map {
-                let tokenString = $0.token
+                let tokenString = $0.token ?? "음슴"
                 print(tokenString)
                 return tokenString
             }

--- a/Segno/Segno/Entity/DiaryDetail.swift
+++ b/Segno/Segno/Entity/DiaryDetail.swift
@@ -5,6 +5,7 @@
 //  Created by Gordon Choi on 2022/11/10.
 //
 
+// TODO: 코어 로케이션에서 좌표만 뽑아와서 저장하기
 import CoreLocation
 
 struct DiaryDetail {

--- a/Segno/Segno/Presentation/Coordinator/LoginCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/LoginCoordinator.swift
@@ -7,9 +7,15 @@
 
 import UIKit
 
+protocol LoginCoordinatorDelegate: AnyObject {
+    func loginDidSucceed(_ coordinator: LoginCoordinator)
+}
+
 final class LoginCoordinator: Coordinator {
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
+    
+    weak var delegate: LoginCoordinatorDelegate?
     
     init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -17,6 +23,17 @@ final class LoginCoordinator: Coordinator {
     
     func start() {
         let vc = LoginViewController()
+        vc.delegate = self
         self.navigationController.pushViewController(vc, animated: true)
+    }
+}
+
+extension LoginCoordinator: LoginViewControllerDelegate {
+    func loginDidSucceed() {
+        print("로그인 성공. 화면 전환")
+    }
+    
+    func loginDidFail() {
+        print("로그인 실패. 얼럿 팝업 반환")
     }
 }

--- a/Segno/Segno/Presentation/Coordinator/LoginCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/LoginCoordinator.swift
@@ -30,7 +30,7 @@ final class LoginCoordinator: Coordinator {
 
 extension LoginCoordinator: LoginViewControllerDelegate {
     func loginDidSucceed() {
-        print("로그인 성공. 화면 전환")
+        delegate?.loginDidSucceed(self)
     }
     
     func loginDidFail() {

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -6,8 +6,9 @@
 //
 
 import UIKit
-import RxSwift
+
 import RxCocoa
+import RxSwift
 import SnapKit
 
 final class DiaryCollectionViewController: UIViewController {

--- a/Segno/Segno/Presentation/ViewController/LoginViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/LoginViewController.swift
@@ -5,12 +5,13 @@
 //  Created by Gordon Choi on 2022/11/09.
 //
 
+import AuthenticationServices
 import UIKit
+
+import GoogleSignIn
 import RxCocoa
 import RxSwift
 import SnapKit
-import AuthenticationServices
-import GoogleSignIn
 
 final class LoginViewController: UIViewController {
     

--- a/Segno/Segno/Presentation/ViewController/LoginViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/LoginViewController.swift
@@ -13,11 +13,18 @@ import RxCocoa
 import RxSwift
 import SnapKit
 
+protocol LoginViewControllerDelegate: AnyObject {
+    func loginDidSucceed()
+    func loginDidFail()
+}
+
 final class LoginViewController: UIViewController {
     
     // MARK: - Property
     private let viewModel: LoginViewModel
     private let disposeBag = DisposeBag()
+    
+    weak var delegate: LoginViewControllerDelegate?
     
     private enum Metric {
         static let googleTitle = "구글 로그인"
@@ -137,7 +144,15 @@ final class LoginViewController: UIViewController {
         viewModel.isLoginSucceeded
             .subscribe(onNext: { [weak self] result in
                 DispatchQueue.main.async {
-                    self?.titleLabel.backgroundColor = result ? .blue : .orange
+                    switch result {
+                    case true:
+                        self?.titleLabel.backgroundColor = .blue
+                        // TODO: 유저 정보를 넣어 줍시다.
+                        self?.delegate?.loginDidSucceed()
+                    case false:
+                        self?.titleLabel.backgroundColor = .orange
+                        self?.delegate?.loginDidFail()
+                    }
                 }
             })
             .disposed(by: disposeBag)

--- a/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
@@ -45,11 +45,12 @@ final class LoginViewModel {
         
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
-            let userIdentifier = appleIDCredential.user // 애플에서 준 토큰
-            guard let fullName = appleIDCredential.fullName,
-                  let email = appleIDCredential.email else {
-                return
-            }
+//            let userIdentifier = appleIDCredential.user // 애플에서 준 토큰
+//            guard let fullName = appleIDCredential.fullName,
+//                  let email = appleIDCredential.email else {
+//                return
+//            }
+            let email = appleIDCredential.email ?? "thefirate@gmail.com"
             
             useCase.sendLoginRequest(email: email)
                 .subscribe(onSuccess: { [weak self] _ in

--- a/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
@@ -5,8 +5,9 @@
 //  Created by YOONJONG on 2022/11/17.
 //
 
-import RxSwift
 import AuthenticationServices
+
+import RxSwift
 
 final class LoginViewModel {
     let useCase: LoginUseCase

--- a/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
@@ -13,32 +13,64 @@ final class LoginViewModel {
     let useCase: LoginUseCase
     private let disposeBag = DisposeBag()
     
+    var isLoginSucceeded = PublishSubject<Bool>()
+    
     init(useCase: LoginUseCase = LoginUseCaseImpl()) {
         self.useCase = useCase
     }
     
-    func signIn(withApple authorization: ASAuthorization) -> Single<Bool> {
-        return Single.create { single in
-            switch authorization.credential {
-            case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                let userIdentifier = appleIDCredential.user
-                guard let fullName = appleIDCredential.fullName,
-                      let email = appleIDCredential.email else {
-                    single(.success(false))
-                    return Disposables.create()
-                }
-                self.useCase.sendLoginRequest(email: email)
-                    .subscribe(onSuccess: { _ in
-                        single(.success(true))
-                    }, onFailure: { _ in
-                        single(.success(false))
-                    })
-                    .disposed(by: self.disposeBag)
-            default:
-                single(.success(false))
-                break
+    func signIn(withApple authorization: ASAuthorization) {
+//        return Single.create { single in
+//            switch authorization.credential {
+//            case let appleIDCredential as ASAuthorizationAppleIDCredential:
+//                let userIdentifier = appleIDCredential.user
+//                guard let fullName = appleIDCredential.fullName,
+//                      let email = appleIDCredential.email else {
+//                    single(.success(false))
+//                    return Disposables.create()
+//                }
+//                self.useCase.sendLoginRequest(email: email)
+//                    .subscribe(onSuccess: { _ in
+//                        single(.success(true))
+//                    }, onFailure: { _ in
+//                        single(.success(false))
+//                    })
+//                    .disposed(by: self.disposeBag)
+//            default:
+//                single(.success(false))
+//                break
+//            }
+//            return Disposables.create()
+//        }
+        
+        switch authorization.credential {
+        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+            let userIdentifier = appleIDCredential.user // 애플에서 준 토큰
+            guard let fullName = appleIDCredential.fullName,
+                  let email = appleIDCredential.email else {
+                return
             }
-            return Disposables.create()
+            
+            useCase.sendLoginRequest(email: email)
+                .subscribe(onSuccess: { [weak self] _ in
+                    self?.isLoginSucceeded.onNext(true)
+                }, onFailure: { [weak self] _ in
+                    self?.isLoginSucceeded.onNext(false)
+                })
+                .disposed(by: disposeBag)
+        default:
+            return
         }
+    }
+    
+    // TODO: 서버 이슈 해결된 뒤, 구글 로그인과 애플 로그인 함수 합치기
+    func signIn(withGoogle email: String) {
+        useCase.sendLoginRequest(email: email)
+            .subscribe(onSuccess: { [weak self] _ in
+                self?.isLoginSucceeded.onNext(true)
+            }, onFailure: { [weak self] _ in
+                self?.isLoginSucceeded.onNext(false)
+            })
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
11/17

## 작업한 내용
### 구글, 애플 로그인 흐름을 통합했습니다.
- 이제 뷰 컨트롤러에서 뷰모델 유즈케이스 ... 다시 뷰모델까지 돌아옵니다.

## 고민한 점 및 어려웠던 점
### 서버 이슈가 있습니다.
- 명세대로 파라미터에 태워서 보냈는데, 응답이 수상쩍습니다. 404 not found가 뜹니다.
- 혹시 서버가 내려가 있나요?
