### PR TITLE
로그인 로직 구현

### DIFF
--- a/Segno/Segno/Data/Repository/LoginRepository.swift
+++ b/Segno/Segno/Data/Repository/LoginRepository.swift
@@ -10,13 +10,24 @@ import Foundation
 import RxSwift
 
 protocol LoginRepository {
-    func sendLoginRequest(email: String) -> Single<TokenDTO>
+    func sendLoginRequest(withApple email: String) -> Single<TokenDTO>
+    func sendLoginRequest(withGoogle email: String) -> Single<TokenDTO>
     func sendLogoutRequest()
 }
 
 final class LoginRepositoryImpl: LoginRepository {
-    func sendLoginRequest(email: String) -> Single<TokenDTO> {
+    func sendLoginRequest(withApple email: String) -> Single<TokenDTO> {
         let endpoint = LoginEndpoint.apple(email)
+        return NetworkManager.shared.call(endpoint)
+            .map {
+                let tokenDTO = try JSONDecoder().decode(TokenDTO.self, from: $0)
+                print(tokenDTO)
+                return tokenDTO
+            }
+    }
+    
+    func sendLoginRequest(withGoogle email: String) -> Single<TokenDTO> {
+        let endpoint = LoginEndpoint.google(email)
         return NetworkManager.shared.call(endpoint)
             .map {
                 let tokenDTO = try JSONDecoder().decode(TokenDTO.self, from: $0)

--- a/Segno/Segno/Domain/UseCase/LoginUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/LoginUseCase.swift
@@ -8,7 +8,8 @@
 import RxSwift
 
 protocol LoginUseCase {
-    func sendLoginRequest(email: String) -> Single<String>
+    func sendLoginRequest(withApple email: String) -> Single<String>
+    func sendLoginRequest(withGoogle email: String) -> Single<String>
 }
 
 final class LoginUseCaseImpl: LoginUseCase {
@@ -27,24 +28,17 @@ final class LoginUseCaseImpl: LoginUseCase {
         self.localUtilityRepository = localUtilityRepository
     }
 
-    func sendLoginRequest(email: String) -> Single<String> {
-//        return Single.create { single in
-//            self.repository.sendLoginRequest(email: email)
-//                .subscribe(onSuccess: { token in
-//                    print("서버에서 받아온 토큰 : ", token)
-//                    single(.success(true))
-//                    // TODO: UserInformation Entity를 생성하여
-//
-//                    // TODO: LocalUtilityRepository에 전달한다.
-//                }, onFailure: { error in
-//                    single(.failure(error))
-//                })
-//                .disposed(by: self.disposeBag)
-//
-//            return Disposables.create()
-//        }
-        
-        return repository.sendLoginRequest(email: email)
+    func sendLoginRequest(withApple email: String) -> Single<String> {
+        return repository.sendLoginRequest(withApple: email)
+            .map {
+                let tokenString = $0.token ?? "음슴"
+                print(tokenString)
+                return tokenString
+            }
+    }
+    
+    func sendLoginRequest(withGoogle email: String) -> Single<String> {
+        return repository.sendLoginRequest(withGoogle: email)
             .map {
                 let tokenString = $0.token ?? "음슴"
                 print(tokenString)

--- a/Segno/Segno/Presentation/ViewController/LoginViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/LoginViewController.swift
@@ -293,7 +293,15 @@ final class LoginViewController: UIViewController {
             Data(base64Encoded: $0)
         }
         
-        if let json = try? JSONSerialization.jsonObject(with: jwtElement[1], options: []) as? [String : Any] {
+        let data = {
+            if jwtElement.count == 1 {
+                return jwtElement[0]
+            } else {
+                return jwtElement[1]
+            }
+        }()
+        
+        if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any] {
             if let email = json["email"] as? String {
                 ret = email
             }

--- a/Segno/Segno/Presentation/ViewController/LoginViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/LoginViewController.swift
@@ -36,7 +36,7 @@ final class LoginViewController: UIViewController {
         
         static let spacingBetweenButtons: CGFloat = 20
         static let inset: CGFloat = 20
-     
+        
         static let titleHeight: CGFloat = 100
         static let titleOffset: CGFloat = 200
         static let subTitleHeight: CGFloat = 50
@@ -237,7 +237,7 @@ final class LoginViewController: UIViewController {
     // MARK: - Public
     private func googleButtonTapped() {
         let signInConfig = GIDConfiguration.init(clientID: "880830660858-2niv4cb94c63omf91uej9f23o7j15n8r.apps.googleusercontent.com")
-
+        
         GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: self) { user, error in
             guard error == nil else { return }
             guard let user = user else { return }
@@ -252,26 +252,26 @@ final class LoginViewController: UIViewController {
                 print("User ID : \(userId)")
                 print("User Email : \(email)")
                 print("User Name : \((fullName))")
-                
                 self.viewModel.signIn(withGoogle: email)
             } else {
                 print("Error : User Data Not Found")
             }
             
             // TODO: ViewModel로 적절한 데이터(authentication / idToken 등) 전송
-//            user.authentication.do { [self] authentication, error in
-//                guard error == nil else { print(error); return }
-//                guard let authentication = authentication else { return }
-//
-//                let idToken = authentication.idToken
-//                print(userId)
-//                print(idToken)
-//            }
+            //            user.authentication.do { [self] authentication, error in
+            //                guard error == nil else { print(error); return }
+            //                guard let authentication = authentication else { return }
+            //
+            //                let idToken = authentication.idToken
+            //                print(userId)
+            //                print(idToken)
+            //            }
         }
     }
     
     private func appleButtonTapped() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
+        
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]
         
@@ -280,36 +280,60 @@ final class LoginViewController: UIViewController {
         authorizationController.presentationContextProvider = self
         authorizationController.performRequests()
     }
+    
+    func jwtParser(_ _jwt: Data?) -> String? {
+        guard let _jwt = _jwt else { return nil}
+        guard let jwt = String(data: _jwt, encoding: .ascii) else { return nil }
+        
+        
+        let jsonString = jwt.split(separator: ".").map {
+            String($0)
+        }.compactMap {
+            Data(base64Encoded: $0)
+        }.compactMap {
+            String(data: $0, encoding: .ascii)
+        }
+        guard let data = jsonString[1].data(using: .utf8) else {
+            return nil
+        }
+        
+        // 태호님 로직 =======
+
+        
+        return "생성된_이메일@naver.com"
+    }
 }
 
 extension LoginViewController: ASAuthorizationControllerDelegate {
     // Apple ID 연동 성공 시
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        // TODO: viewModel로 authoriztion 전송하기
-        viewModel.signIn(withApple: authorization)
         // TODO: 코디네이터에게 알리기
         
         // 아래는 테스트용 출력
-        #if DEBUG
+#if DEBUG
         switch authorization.credential {
-        // Apple ID
+            // Apple ID
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                
             // 계정 정보 가져오기
             let userIdentifier = appleIDCredential.user
             let fullName = appleIDCredential.fullName
             let email = appleIDCredential.email
-                
+            
             print("User ID : \(userIdentifier)")
             print("User Email : \(email ?? "")")
             print("User Name : \((fullName?.givenName ?? "") + (fullName?.familyName ?? ""))")
             
+            guard let email = jwtParser(appleIDCredential.identityToken) else { return }
+            
+            // TODO: viewModel로 authoriztion 전송하기
+//            viewModel.signIn(withApple: email)
+                    
         default:
             break
         }
-        #endif
+#endif
     }
-        
+    
     // Apple ID 연동 실패 시
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         // Handle error.

--- a/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
@@ -19,54 +19,19 @@ final class LoginViewModel {
         self.useCase = useCase
     }
     
-    func signIn(withApple authorization: ASAuthorization) {
-//        return Single.create { single in
-//            switch authorization.credential {
-//            case let appleIDCredential as ASAuthorizationAppleIDCredential:
-//                let userIdentifier = appleIDCredential.user
-//                guard let fullName = appleIDCredential.fullName,
-//                      let email = appleIDCredential.email else {
-//                    single(.success(false))
-//                    return Disposables.create()
-//                }
-//                self.useCase.sendLoginRequest(email: email)
-//                    .subscribe(onSuccess: { _ in
-//                        single(.success(true))
-//                    }, onFailure: { _ in
-//                        single(.success(false))
-//                    })
-//                    .disposed(by: self.disposeBag)
-//            default:
-//                single(.success(false))
-//                break
-//            }
-//            return Disposables.create()
-//        }
-        
-        switch authorization.credential {
-        case let appleIDCredential as ASAuthorizationAppleIDCredential:
-//            let userIdentifier = appleIDCredential.user // 애플에서 준 토큰
-//            guard let fullName = appleIDCredential.fullName,
-//                  let email = appleIDCredential.email else {
-//                return
-//            }
-            let email = appleIDCredential.email ?? "thefirate@gmail.com"
-            
-            useCase.sendLoginRequest(email: email)
+    func signIn(withApple email: String) {
+        useCase.sendLoginRequest(withApple: email)
                 .subscribe(onSuccess: { [weak self] _ in
                     self?.isLoginSucceeded.onNext(true)
                 }, onFailure: { [weak self] _ in
                     self?.isLoginSucceeded.onNext(false)
                 })
                 .disposed(by: disposeBag)
-        default:
-            return
-        }
     }
     
     // TODO: 서버 이슈 해결된 뒤, 구글 로그인과 애플 로그인 함수 합치기
     func signIn(withGoogle email: String) {
-        useCase.sendLoginRequest(email: email)
+        useCase.sendLoginRequest(withGoogle: email)
             .subscribe(onSuccess: { [weak self] _ in
                 self?.isLoginSucceeded.onNext(true)
             }, onFailure: { [weak self] _ in


### PR DESCRIPTION
11/21 

## 작업한 내용
### 애플 로그인 로직 수정
- 뷰모델, 유즈케이스, 레포지토리에서 login 요청 보내는 메서드를 각 OAuth 별로 분리하였습니다.
- JWT로부터 이메일을 반환하는 메서드를 추가하였습니다.
- 응답으로 오는 JWT 구성 요소가 계속 변동되어, 이를 처리해주는 로직을 추가하였습니다.

## 고민한 점 및 어려웠던 점
### 응답으로 오는 JWT 구성요소가 계속 변동되는 문제가 있었습니다.
- 현재로서는 원인을 찾을 수 없어 우선 JWT Data로부터 반환되는 구성요소 개수에 따라 다른 인덱스의 값을 리턴하도록 하였습니다.
