### PR TITLE
로그인 프로세스 분리

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */; };
 		4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D78292522B7005ABA8F /* BaseURL.swift */; };
 		4F4E0D7B29252526005ABA8F /* TokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7A29252526005ABA8F /* TokenDTO.swift */; };
+		4F6F74B1292C9BF3007E7AC1 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6F74B0292C9BF3007E7AC1 /* UserInfo.swift */; };
 		4F9A001B292227D7007D9057 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001A292227D7007D9057 /* NetworkManager.swift */; };
 		4F9A001D29222B1B007D9057 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001C29222B1B007D9057 /* Endpoint.swift */; };
 		4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001E29222C97007D9057 /* NetworkError.swift */; };
@@ -72,6 +73,7 @@
 		4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEndpoint.swift; sourceTree = "<group>"; };
 		4F4E0D78292522B7005ABA8F /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
 		4F4E0D7A29252526005ABA8F /* TokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDTO.swift; sourceTree = "<group>"; };
+		4F6F74B0292C9BF3007E7AC1 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		4F9A001A292227D7007D9057 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4F9A001C29222B1B007D9057 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		4F9A001E29222C97007D9057 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */,
 				4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */,
 				4FEBFAAE291CF9F300E78139 /* MusicInfo.swift */,
+				4F6F74B0292C9BF3007E7AC1 /* UserInfo.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -470,6 +473,7 @@
 				4F9A001D29222B1B007D9057 /* Endpoint.swift in Sources */,
 				4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */,
 				666E6F8E291CFADD00CECD4B /* MyPageViewController.swift in Sources */,
+				4F6F74B1292C9BF3007E7AC1 /* UserInfo.swift in Sources */,
 				4FA3242B2923646F00DB04D5 /* DiaryListItemEndpoint.swift in Sources */,
 				791837FF292225DC00BC6992 /* UIColor+.swift in Sources */,
 				666E6F7F291CF46800CECD4B /* AppCoordinator.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -624,7 +624,7 @@
 				CODE_SIGN_ENTITLEMENTS = Segno/Segno.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PN5JFN8NYT;
+				DEVELOPMENT_TEAM = H5UNW2D34P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -637,7 +637,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.oldstar.Segno;
+				PRODUCT_BUNDLE_IDENTIFIER = com.oldstar.segnobydalsegno;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -653,7 +653,7 @@
 				CODE_SIGN_ENTITLEMENTS = Segno/Segno.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PN5JFN8NYT;
+				DEVELOPMENT_TEAM = H5UNW2D34P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -666,7 +666,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.oldstar.Segno;
+				PRODUCT_BUNDLE_IDENTIFIER = com.oldstar.segnobydalsegno;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Segno/Segno/Data/Session/LoginSession.swift
+++ b/Segno/Segno/Data/Session/LoginSession.swift
@@ -8,30 +8,55 @@
 import AuthenticationServices
 import Foundation
 
+import GoogleSignIn
 import RxSwift
 
-typealias LoginResult = Result<ASAuthorizationAppleIDCredential, Error>
+typealias AppleLoginResult = Result<ASAuthorizationAppleIDCredential, Error>
+typealias GoogleLoginResult = Result<String, Error>
 
 final class LoginSession: NSObject {
     static let shared = LoginSession()
     
     var authorizationController: ASAuthorizationController?
-    var appleCredentialResult = PublishSubject<LoginResult>()
+    var appleCredentialResult = PublishSubject<AppleLoginResult>()
+    var googleLoginResult = PublishSubject<GoogleLoginResult>()
     
     private override init() { }
     
-    func setPresentationContextProvider(_ object: ASAuthorizationControllerPresentationContextProviding) {
-        authorizationController?.presentationContextProvider = object
-    }
-    
-    func performAppleLogin() {
+    func performAppleLogin(on presenter: ASAuthorizationControllerPresentationContextProviding) {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]
         
         authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController?.delegate = self
+        authorizationController?.presentationContextProvider = presenter
         authorizationController?.performRequests()
+    }
+    
+    func performGoogleLogin(_ presenter: UIViewController) {
+        let signInConfig = GIDConfiguration.init(clientID: "880830660858-2niv4cb94c63omf91uej9f23o7j15n8r.apps.googleusercontent.com")
+        
+        GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: presenter) { user, error in
+            guard error == nil else { return }
+            guard let user = user else { return }
+            
+            if let userId = user.userID,                  // For client-side use only!
+               let idToken = user.authentication.idToken, // Safe to send to the server
+               let fullName = user.profile?.name,
+               let givenName = user.profile?.givenName,
+               let familyName = user.profile?.familyName,
+               let email = user.profile?.email {
+                print("Token : \(idToken)")
+                print("User ID : \(userId)")
+                print("User Email : \(email)")
+                print("User Name : \((fullName))")
+                self.googleLoginResult.onNext(.success(email))
+            } else {
+                print("Error : User Data Not Found")
+                // TODO: 커스텀 에러 타입 적용
+            }
+        }
     }
 }
 

--- a/Segno/Segno/Domain/UseCase/LoginUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/LoginUseCase.swift
@@ -31,7 +31,7 @@ final class LoginUseCaseImpl: LoginUseCase {
     func sendLoginRequest(withApple email: String) -> Single<String> {
         return repository.sendLoginRequest(withApple: email)
             .map {
-                let tokenString = $0.token ?? "음슴"
+                let tokenString = $0.token ?? "NO TOKEN"
                 print(tokenString)
                 return tokenString
             }
@@ -40,7 +40,7 @@ final class LoginUseCaseImpl: LoginUseCase {
     func sendLoginRequest(withGoogle email: String) -> Single<String> {
         return repository.sendLoginRequest(withGoogle: email)
             .map {
-                let tokenString = $0.token ?? "음슴"
+                let tokenString = $0.token ?? "NO TOKEN"
                 print(tokenString)
                 return tokenString
             }

--- a/Segno/Segno/Domain/UseCase/LoginUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/LoginUseCase.swift
@@ -8,8 +8,8 @@
 import RxSwift
 
 protocol LoginUseCase {
-    func sendLoginRequest(withApple email: String) -> Single<String>
-    func sendLoginRequest(withGoogle email: String) -> Single<String>
+    func sendLoginRequest(withApple email: String) -> Single<Bool>
+    func sendLoginRequest(withGoogle email: String) -> Single<Bool>
 }
 
 final class LoginUseCaseImpl: LoginUseCase {
@@ -28,21 +28,27 @@ final class LoginUseCaseImpl: LoginUseCase {
         self.localUtilityRepository = localUtilityRepository
     }
 
-    func sendLoginRequest(withApple email: String) -> Single<String> {
+    func sendLoginRequest(withApple email: String) -> Single<Bool> {
         return repository.sendLoginRequest(withApple: email)
             .map {
-                let tokenString = $0.token ?? "NO TOKEN"
+                guard let tokenString = $0.token else {
+                    return false
+                }
+                
                 print(tokenString)
-                return tokenString
+                return true
             }
     }
     
-    func sendLoginRequest(withGoogle email: String) -> Single<String> {
+    func sendLoginRequest(withGoogle email: String) -> Single<Bool> {
         return repository.sendLoginRequest(withGoogle: email)
             .map {
-                let tokenString = $0.token ?? "NO TOKEN"
+                guard let tokenString = $0.token else {
+                    return false
+                }
+                
                 print(tokenString)
-                return tokenString
+                return true
             }
     }
 }

--- a/Segno/Segno/Entity/UserInfo.swift
+++ b/Segno/Segno/Entity/UserInfo.swift
@@ -1,0 +1,11 @@
+//
+//  UserInfo.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/22.
+//
+
+struct UserInfo {
+    let token: String
+    let email: String
+}

--- a/Segno/Segno/Presentation/ViewController/LoginViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/LoginViewController.swift
@@ -8,7 +8,6 @@
 import AuthenticationServices
 import UIKit
 
-import GoogleSignIn
 import RxCocoa
 import RxSwift
 import SnapKit
@@ -236,37 +235,16 @@ final class LoginViewController: UIViewController {
     
     // MARK: - Public
     private func googleButtonTapped() {
-        let signInConfig = GIDConfiguration.init(clientID: "880830660858-2niv4cb94c63omf91uej9f23o7j15n8r.apps.googleusercontent.com")
-        
-        GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: self) { user, error in
-            guard error == nil else { return }
-            guard let user = user else { return }
-            
-            if let userId = user.userID,                  // For client-side use only!
-               let idToken = user.authentication.idToken, // Safe to send to the server
-               let fullName = user.profile?.name,
-               let givenName = user.profile?.givenName,
-               let familyName = user.profile?.familyName,
-               let email = user.profile?.email {
-                print("Token : \(idToken)")
-                print("User ID : \(userId)")
-                print("User Email : \(email)")
-                print("User Name : \((fullName))")
-                self.viewModel.signIn(withGoogle: email)
-            } else {
-                print("Error : User Data Not Found")
-            }
-        }
+        viewModel.performGoogleLogin(on: self)
     }
     
     private func appleButtonTapped() {
-        viewModel.setPresentationContextProvider(self)
-        viewModel.performAppleLogin()
+        viewModel.performAppleLogin(on: self)
     }
 }
 
 extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return self.view.window ?? UIWindow()
+        return view.window ?? UIWindow()
     }
 }

--- a/Segno/Segno/Presentation/ViewController/LoginViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/LoginViewController.swift
@@ -134,12 +134,12 @@ final class LoginViewController: UIViewController {
         setupLayout()
         setupRx()
         
-//        testSubscribe()
+        subscribeLoginResult()
     }
     
     // MARK: - Private
     
-    private func testSubscribe() {
+    private func subscribeLoginResult() {
         viewModel.isLoginSucceeded
             .subscribe(onNext: { [weak self] result in
                 DispatchQueue.main.async {

--- a/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
@@ -66,7 +66,6 @@ final class LoginViewModel {
                 .disposed(by: disposeBag)
     }
     
-    // TODO: 서버 이슈 해결된 뒤, 구글 로그인과 애플 로그인 함수 합치기
     func signIn(withGoogle email: String) {
         useCase.sendLoginRequest(withGoogle: email)
             .subscribe(onSuccess: { [weak self] _ in

--- a/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
@@ -58,8 +58,8 @@ final class LoginViewModel {
     
     func signIn(withApple email: String) {
         useCase.sendLoginRequest(withApple: email)
-                .subscribe(onSuccess: { [weak self] _ in
-                    self?.isLoginSucceeded.onNext(true)
+                .subscribe(onSuccess: { [weak self] result in
+                    self?.isLoginSucceeded.onNext(result)
                 }, onFailure: { [weak self] _ in
                     self?.isLoginSucceeded.onNext(false)
                 })
@@ -68,8 +68,8 @@ final class LoginViewModel {
     
     func signIn(withGoogle email: String) {
         useCase.sendLoginRequest(withGoogle: email)
-            .subscribe(onSuccess: { [weak self] _ in
-                self?.isLoginSucceeded.onNext(true)
+            .subscribe(onSuccess: { [weak self] result in
+                self?.isLoginSucceeded.onNext(result)
             }, onFailure: { [weak self] _ in
                 self?.isLoginSucceeded.onNext(false)
             })

--- a/Segno/Segno/Resource/Info.plist
+++ b/Segno/Segno/Resource/Info.plist
@@ -2,17 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleURLTypes</key>
-    <array>
-        <dict>
-            <key>CFBundleTypeRole</key>
-            <string>Editor</string>
-            <key>CFBundleURLSchemes</key>
-            <array>
-                <string>com.googleusercontent.apps.880830660858-2niv4cb94c63omf91uej9f23o7j15n8r</string>
-            </array>
-        </dict>
-    </array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.880830660858-2niv4cb94c63omf91uej9f23o7j15n8r</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Cafe24Shiningstar.ttf</string>


### PR DESCRIPTION
11/22 #43 #45 #46 #60 #61 #64 #66 

## 작업한 내용
### 로그인 세션에 구글 로그인을 추가했습니다.
- 뷰 컨트롤러와 뷰 모델에 붙어 있던, 구글 로그인 서버에 요청하는 과정을 이관했습니다.
### 로그인 성공과 실패 여부는 유즈케이스에서 알려주도록 변경했습니다.
- 토큰 자체는 키체인에 저장하도록 했습니다.
- 향후 로컬 유틸리티 레포지토리에 적절한 처리를 할 계획입니다.

## 고민한 점 및 어려웠던 점
### 로컬 유틸리티 레포지토리의 메서드가 반응형일 필요가 있는지에 대해 고민했습니다.
- 반응형 프로그래밍이란, 시간에 따른 이벤트의 흐름이 변화하는 것을 감지해 작동하는 것입니다. 따라서, 응답을 받아오는 데 "시간"이 걸리는 작업, 대표적으로 비동기 작업에 활용합니다.
- 하지만 키체인에서 유저 데이터를 받아오는 작업의 경우 비동기 작업이 아닙니다. 따라서 반응형 프레임워크 Rx를 사용하는 것은 과도하다고 판단했습니다.
- 이에 따라 리팩토링한 후 연동할 계획입니다.
### 판단할 수 있는 유저 정보를 전달하는 것에 대해 고민했습니다.
- 키체인에 토큰을 저장하는 이유는, 보안을 유지하기 위함입니다.
- 전통적인 키체인의 사용법에 의하면, id와 패스워드를 저장한다고 할 때, id를 키로써 사용해 패스워드에 해당하는 토큰을 가져와야 합니다.
- 하지만 만약 그렇다면, id에 해당하는 이메일에 대한 정보를 일기 목록 뷰 컨트롤러와 마이페이지 뷰 컨트롤러가 알고 있어야 합니다. 이를 위해서는 로그인 코디네이터 - 앱 코디네이터 - 탭 바 코디네이터 - 목표 코디네이터에 이르는 데이터 전달 과정이 필요합니다.
- 일단 이에 대해서는 유보 상태입니다.
