### PR TITLE
DiaryDetailViewController 화면 구성

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414DA2923606B007C9132 /* DiaryListUseCase.swift */; };
 		98B5263E292CA46C00446413 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263D292CA46C00446413 /* TagView.swift */; };
 		98B52640292CB92900446413 /* MusicContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263F292CB92900446413 /* MusicContentView.swift */; };
+		98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -113,6 +114,7 @@
 		988414DA2923606B007C9132 /* DiaryListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListUseCase.swift; sourceTree = "<group>"; };
 		98B5263D292CA46C00446413 /* TagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagView.swift; sourceTree = "<group>"; };
 		98B5263F292CB92900446413 /* MusicContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicContentView.swift; sourceTree = "<group>"; };
+		98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationContentView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -270,6 +272,7 @@
 				66F0D7ED2925FF8B0074872E /* DiaryCell.swift */,
 				98B5263D292CA46C00446413 /* TagView.swift */,
 				98B5263F292CB92900446413 /* MusicContentView.swift */,
+				98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -451,6 +454,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */,
 				4F4E0D3E2924B925005ABA8F /* LoginRepository.swift in Sources */,
 				4F9A00212922338E007D9057 /* AppDelegate.swift in Sources */,
 				66F0D7EE2925FF8B0074872E /* DiaryCell.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -51,12 +51,14 @@
 		79183800292225DC00BC6992 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791837FE292225DC00BC6992 /* UIFont+.swift */; };
 		7918380829233F7100BC6992 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7918380729233F7100BC6992 /* UIButton+.swift */; };
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
+		982A3699292C905300FDC6CF /* DiaryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */; };
 		9841D6172925FACC00318EA9 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9841D6162925FACC00318EA9 /* LoginUseCase.swift */; };
 		9841D61B2926131200318EA9 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9841D61A2926131200318EA9 /* LoginViewModel.swift */; };
 		988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414AD2922235B007C9132 /* LocalUtilityRepository.swift */; };
 		988414D72923304F007C9132 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414D62923304F007C9132 /* KeychainError.swift */; };
 		988414D929235345007C9132 /* DiaryCollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414D829235345007C9132 /* DiaryCollectionViewModel.swift */; };
 		988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414DA2923606B007C9132 /* DiaryListUseCase.swift */; };
+		98B5263E292CA46C00446413 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263D292CA46C00446413 /* TagView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -101,12 +103,14 @@
 		791837FE292225DC00BC6992 /* UIFont+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		7918380729233F7100BC6992 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
+		982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewController.swift; sourceTree = "<group>"; };
 		9841D6162925FACC00318EA9 /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
 		9841D61A2926131200318EA9 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		988414AD2922235B007C9132 /* LocalUtilityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUtilityRepository.swift; sourceTree = "<group>"; };
 		988414D62923304F007C9132 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
 		988414D829235345007C9132 /* DiaryCollectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCollectionViewModel.swift; sourceTree = "<group>"; };
 		988414DA2923606B007C9132 /* DiaryListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListUseCase.swift; sourceTree = "<group>"; };
+		98B5263D292CA46C00446413 /* TagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -252,6 +256,7 @@
 			children = (
 				4F317780291BE4710019BDFC /* LoginViewController.swift */,
 				666E6F8B291CFAC200CECD4B /* DiaryCollectionViewController.swift */,
+				982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */,
 				666E6F8D291CFADD00CECD4B /* MyPageViewController.swift */,
 			);
 			path = ViewController;
@@ -261,6 +266,7 @@
 			isa = PBXGroup;
 			children = (
 				66F0D7ED2925FF8B0074872E /* DiaryCell.swift */,
+				98B5263D292CA46C00446413 /* TagView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -463,6 +469,7 @@
 				988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */,
 				4FCAC5C2292B5C9000BF9CDD /* LoginSession.swift in Sources */,
 				666E6F7D291CF45600CECD4B /* Coordinator.swift in Sources */,
+				982A3699292C905300FDC6CF /* DiaryDetailViewController.swift in Sources */,
 				666E6F8C291CFAC200CECD4B /* DiaryCollectionViewController.swift in Sources */,
 				666E6F8A291CF82700CECD4B /* TabBarPageCase.swift in Sources */,
 				79183800292225DC00BC6992 /* UIFont+.swift in Sources */,
@@ -475,6 +482,7 @@
 				666E6F7F291CF46800CECD4B /* AppCoordinator.swift in Sources */,
 				9841D61B2926131200318EA9 /* LoginViewModel.swift in Sources */,
 				988414D72923304F007C9132 /* KeychainError.swift in Sources */,
+				98B5263E292CA46C00446413 /* TagView.swift in Sources */,
 				4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */,
 				4FA324262923600C00DB04D5 /* DiaryListDTO.swift in Sources */,
 				666E6F87291CF4B400CECD4B /* DiaryCoordinator.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		988414D929235345007C9132 /* DiaryCollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414D829235345007C9132 /* DiaryCollectionViewModel.swift */; };
 		988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414DA2923606B007C9132 /* DiaryListUseCase.swift */; };
 		98B5263E292CA46C00446413 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263D292CA46C00446413 /* TagView.swift */; };
+		98B52640292CB92900446413 /* MusicContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263F292CB92900446413 /* MusicContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -111,6 +112,7 @@
 		988414D829235345007C9132 /* DiaryCollectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCollectionViewModel.swift; sourceTree = "<group>"; };
 		988414DA2923606B007C9132 /* DiaryListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListUseCase.swift; sourceTree = "<group>"; };
 		98B5263D292CA46C00446413 /* TagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagView.swift; sourceTree = "<group>"; };
+		98B5263F292CB92900446413 /* MusicContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicContentView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -267,6 +269,7 @@
 			children = (
 				66F0D7ED2925FF8B0074872E /* DiaryCell.swift */,
 				98B5263D292CA46C00446413 /* TagView.swift */,
+				98B5263F292CB92900446413 /* MusicContentView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -488,6 +491,7 @@
 				666E6F87291CF4B400CECD4B /* DiaryCoordinator.swift in Sources */,
 				4F31777F291BE4710019BDFC /* SceneDelegate.swift in Sources */,
 				4F4E0D74292521D0005ABA8F /* UserInfoDTO.swift in Sources */,
+				98B52640292CB92900446413 /* MusicContentView.swift in Sources */,
 				4FA32428292363AB00DB04D5 /* DiaryRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -11,20 +11,20 @@ import SnapKit
 
 final class LocationContentView: UIView {
     
-    private let titleLabel: UILabel = {
+    private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .bold)
         label.text = "위치"
         return label
     }()
     
-    private let locationLabel: UILabel = {
+    private lazy var locationLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16)
         return label
     }()
     
-    private let mapButton: UIButton = {
+    private lazy var mapButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "map.fill"), for: .normal)
         button.tintColor = .white

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -1,0 +1,70 @@
+//
+//  LocationContentView.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/23.
+//
+
+import UIKit
+
+import SnapKit
+
+final class LocationContentView: UIView {
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .bold)
+        label.text = "위치"
+        return label
+    }()
+    
+    private let locationLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        return label
+    }()
+    
+    private let mapButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "map.fill"), for: .normal)
+        button.tintColor = .white
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setLayout() {
+        [titleLabel, locationLabel, mapButton].forEach {
+            addSubview($0)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(10)
+        }
+        
+        locationLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(10)
+        }
+        
+        mapButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(30)
+            $0.trailing.equalToSuperview().inset(10)
+        }
+    }
+    
+    func setLocation(location: String) {
+        locationLabel.text = location
+    }
+}
+

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -10,25 +10,25 @@ import UIKit
 import SnapKit
 
 final class MusicContentView: UIView {
-    private let albumArtImageView: UIImageView = {
+    private lazy var albumArtImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .systemMint
         return imageView
     }()
     
-    private let titleLabel: UILabel = {
+    private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .bold)
         return label
     }()
     
-    private let artistLabel: UILabel = {
+    private lazy var artistLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16)
         return label
     }()
     
-    private let playButton: UIButton = {
+    private lazy var playButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "play.fill"), for: .normal)
         button.tintColor = .white

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -1,0 +1,68 @@
+//
+//  MusicContentView.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/22.
+//
+
+import UIKit
+
+import SnapKit
+
+final class MusicContentView: UIView {
+    private let albumArtImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .systemMint
+        return imageView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .bold)
+        return label
+    }()
+    
+    private let artistLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setLayout() {
+        [albumArtImageView, titleLabel, artistLabel].forEach {
+            addSubview($0)
+        }
+        
+        albumArtImageView.snp.makeConstraints {
+            $0.width.height.equalTo(30)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(16)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(albumArtImageView.snp.trailing).offset(10)
+        }
+        
+        artistLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(10)
+        }
+    }
+    
+    func setMusic(title: String, artist: String) {
+        titleLabel.text = title
+        artistLabel.text = artist
+    }
+}
+

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -28,6 +28,13 @@ final class MusicContentView: UIView {
         return label
     }()
     
+    private let playButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "play.fill"), for: .normal)
+        button.tintColor = .white
+        return button
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -39,7 +46,7 @@ final class MusicContentView: UIView {
     }
     
     private func setLayout() {
-        [albumArtImageView, titleLabel, artistLabel].forEach {
+        [albumArtImageView, titleLabel, artistLabel, playButton].forEach {
             addSubview($0)
         }
         
@@ -57,6 +64,12 @@ final class MusicContentView: UIView {
         artistLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalTo(titleLabel.snp.trailing).offset(10)
+        }
+        
+        playButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(30)
+            $0.trailing.equalToSuperview().inset(10)
         }
     }
     

--- a/Segno/Segno/Presentation/View/TagView.swift
+++ b/Segno/Segno/Presentation/View/TagView.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 final class TagView: UIView {
 
-    private let tagLabel: UILabel = {
+    private lazy var tagLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16)
         return label

--- a/Segno/Segno/Presentation/View/TagView.swift
+++ b/Segno/Segno/Presentation/View/TagView.swift
@@ -1,0 +1,38 @@
+//
+//  TagView.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/22.
+//
+
+import UIKit
+import SnapKit
+
+final class TagView: UIView {
+
+    private let tagLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        return label
+    }()
+    
+    init(tagTitle: String) {
+        super.init(frame: CGRect())
+    
+        setupLayout(tagTitle: tagTitle)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayout(tagTitle: String) {
+        addSubview(tagLabel)
+        tagLabel.text = tagTitle
+        tagLabel.snp.makeConstraints {
+            $0.width.equalTo(self.snp.width)
+            $0.centerY.equalTo(self.snp.centerY)
+        }
+        backgroundColor = .systemPurple
+    }
+}

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -78,6 +78,12 @@ final class DiaryDetailViewController: UIViewController {
         return textView
     }()
     
+    private let musicContentView: MusicContentView = {
+        let musicContentView = MusicContentView()
+        musicContentView.backgroundColor = .systemGreen
+        return musicContentView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -92,7 +98,7 @@ final class DiaryDetailViewController: UIViewController {
     private func setupLayout() {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
-        [dateLabel, titleLabel, tagScrollView, imageView, textView].forEach {
+        [dateLabel, titleLabel, tagScrollView, imageView, textView, musicContentView].forEach {
             stackView.addArrangedSubview($0)
         }
         tagScrollView.addSubview(tagStackView)
@@ -129,6 +135,11 @@ final class DiaryDetailViewController: UIViewController {
             $0.width.equalTo(view.snp.width)
             $0.height.equalTo(100)
         }
+        
+        musicContentView.snp.makeConstraints {
+            $0.width.equalTo(view.snp.width)
+            $0.height.equalTo(50)
+        }
     }
     
     private func setTemporaryData() {
@@ -141,6 +152,7 @@ final class DiaryDetailViewController: UIViewController {
         [tagView1, tagView2, tagView3].forEach {
             tagViews.append($0)
         }
+        musicContentView.setMusic(title: "Gen Hoshino", artist: "Comedy")
     }
     
     

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -12,7 +12,10 @@ import RxSwift
 import SnapKit
 
 final class DiaryDetailViewController: UIViewController {
-
+    private enum Metric {
+        static let textViewPlaceHolder: String = "내용을 입력하세요."
+    }
+    
     let disposeBag = DisposeBag()
 //    private let viewModel: DiaryDetailViewModel
     
@@ -66,6 +69,15 @@ final class DiaryDetailViewController: UIViewController {
         return imageView
     }()
     
+    private let textView: UITextView = {
+        let textView = UITextView()
+        textView.backgroundColor = .systemGray5
+        textView.text = Metric.textViewPlaceHolder
+        textView.textColor = .gray
+        textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        return textView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -73,10 +85,14 @@ final class DiaryDetailViewController: UIViewController {
         setupLayout()
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+    
     private func setupLayout() {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
-        [datelabel, titleLabel, tagScrollView, imageView].forEach {
+        [datelabel, titleLabel, tagScrollView, imageView, textView].forEach {
             stackView.addArrangedSubview($0)
         }
         tagScrollView.addSubview(tagStackView)
@@ -107,6 +123,12 @@ final class DiaryDetailViewController: UIViewController {
             $0.width.height.equalTo(view.snp.width)
             
         }
+        
+        textView.delegate = self
+        textView.snp.makeConstraints {
+            $0.width.equalTo(view.snp.width)
+            $0.height.equalTo(100)
+        }
     }
     
     private func setTemporaryData() {
@@ -118,6 +140,24 @@ final class DiaryDetailViewController: UIViewController {
         let tagView3 = TagView(tagTitle: "강릉 여행")
         [tagView1, tagView2, tagView3].forEach {
             tagViews.append($0)
+        }
+    }
+    
+    
+}
+
+extension DiaryDetailViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == Metric.textViewPlaceHolder {
+            textView.text = nil
+            textView.textColor = .black
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            textView.text = Metric.textViewPlaceHolder
+            textView.textColor = .gray
         }
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -44,6 +44,22 @@ final class DiaryDetailViewController: UIViewController {
         return label
     }()
     
+    private let tagScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.backgroundColor = .systemMint
+        return scrollView
+    }()
+    
+    private let tagStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.backgroundColor = .systemBrown
+        stackView.spacing = 20
+        return stackView
+    }()
+    
+    private var tagViews: [UIView] = []
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -54,8 +70,13 @@ final class DiaryDetailViewController: UIViewController {
     private func setupLayout() {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
-        [datelabel, titleLabel].forEach {
+        [datelabel, titleLabel, tagScrollView].forEach {
             stackView.addArrangedSubview($0)
+        }
+        tagScrollView.addSubview(tagStackView)
+        
+        tagViews.forEach {
+            tagStackView.addArrangedSubview($0)
         }
         
         scrollView.snp.makeConstraints {
@@ -67,11 +88,26 @@ final class DiaryDetailViewController: UIViewController {
             $0.width.equalTo(scrollView.snp.width)
         }
         
+        tagScrollView.snp.makeConstraints {
+            $0.height.equalTo(30)
+        }
+        
+        tagStackView.snp.makeConstraints {
+            $0.edges.equalTo(tagScrollView)
+            $0.height.equalTo(tagScrollView.snp.height)
+        }
     }
     
     private func setTemporaryData() {
         datelabel.text = "11월 22일 14:54"
         titleLabel.text = "서현에서"
+        
+        let tagView1 = TagView(tagTitle: "음악")
+        let tagView2 = TagView(tagTitle: "휴식")
+        let tagView3 = TagView(tagTitle: "강릉 여행")
+        [tagView1, tagView2, tagView3].forEach {
+            tagViews.append($0)
+        }
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -84,6 +84,12 @@ final class DiaryDetailViewController: UIViewController {
         return musicContentView
     }()
     
+    private let locationContentView: LocationContentView = {
+        let locationContentView = LocationContentView()
+        locationContentView.backgroundColor = .orange
+        return locationContentView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -98,7 +104,7 @@ final class DiaryDetailViewController: UIViewController {
     private func setupLayout() {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
-        [dateLabel, titleLabel, tagScrollView, imageView, textView, musicContentView].forEach {
+        [dateLabel, titleLabel, tagScrollView, imageView, textView, musicContentView, locationContentView].forEach {
             stackView.addArrangedSubview($0)
         }
         tagScrollView.addSubview(tagStackView)
@@ -133,10 +139,15 @@ final class DiaryDetailViewController: UIViewController {
         textView.delegate = self
         textView.snp.makeConstraints {
             $0.width.equalTo(view.snp.width)
-            $0.height.equalTo(100)
+            $0.height.equalTo(200)
         }
         
         musicContentView.snp.makeConstraints {
+            $0.width.equalTo(view.snp.width)
+            $0.height.equalTo(50)
+        }
+        
+        locationContentView.snp.makeConstraints {
             $0.width.equalTo(view.snp.width)
             $0.height.equalTo(50)
         }
@@ -153,6 +164,7 @@ final class DiaryDetailViewController: UIViewController {
             tagViews.append($0)
         }
         musicContentView.setMusic(title: "Comedy", artist: "Gen Hoshino")
+        locationContentView.setLocation(location: "경기도 성남시 분당구")
     }
     
     

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -60,6 +60,12 @@ final class DiaryDetailViewController: UIViewController {
     
     private var tagViews: [UIView] = []
     
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .systemBlue
+        return imageView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -70,7 +76,7 @@ final class DiaryDetailViewController: UIViewController {
     private func setupLayout() {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
-        [datelabel, titleLabel, tagScrollView].forEach {
+        [datelabel, titleLabel, tagScrollView, imageView].forEach {
             stackView.addArrangedSubview($0)
         }
         tagScrollView.addSubview(tagStackView)
@@ -95,6 +101,11 @@ final class DiaryDetailViewController: UIViewController {
         tagStackView.snp.makeConstraints {
             $0.edges.equalTo(tagScrollView)
             $0.height.equalTo(tagScrollView.snp.height)
+        }
+        
+        imageView.snp.makeConstraints {
+            $0.width.height.equalTo(view.snp.width)
+            
         }
     }
     

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -1,0 +1,118 @@
+//
+//  DiaryDetailViewController.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/22.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class DiaryDetailViewController: UIViewController {
+
+    let disposeBag = DisposeBag()
+//    private let viewModel: DiaryDetailViewModel
+    
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.backgroundColor = .systemPink
+        return scrollView
+    }()
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.backgroundColor = .systemYellow
+        stackView.spacing = 10
+        return stackView
+    }()
+    
+    private let datelabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 20, weight: .light)
+        label.backgroundColor = #colorLiteral(red: 0.2745098174, green: 0.4862745106, blue: 0.1411764771, alpha: 1)
+        return label
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 30, weight: .bold)
+        label.backgroundColor = #colorLiteral(red: 0.3647058904, green: 0.06666667014, blue: 0.9686274529, alpha: 1)
+        return label
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setTemporaryData()
+        setupLayout()
+    }
+    
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(stackView)
+        [datelabel, titleLabel].forEach {
+            stackView.addArrangedSubview($0)
+        }
+        
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.edges.equalTo(scrollView)
+            $0.width.equalTo(scrollView.snp.width)
+        }
+        
+    }
+    
+    private func setTemporaryData() {
+        datelabel.text = "11월 22일 14:54"
+        titleLabel.text = "서현에서"
+    }
+}
+
+enum DeviceType {
+    case iPhone14Pro
+
+    func name() -> String {
+        switch self {
+        case .iPhone14Pro:
+            return "iPhone 14 Pro"
+        }
+    }
+}
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+extension UIViewController {
+
+    private struct Preview: UIViewControllerRepresentable {
+        let viewController: UIViewController
+
+        func makeUIViewController(context: Context) -> UIViewController {
+            return viewController
+        }
+
+        func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        }
+    }
+
+    func showPreview(_ deviceType: DeviceType = .iPhone14Pro) -> some View {
+        Preview(viewController: self).previewDevice(PreviewDevice(rawValue: deviceType.name()))
+    }
+}
+#endif
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct ViewController_Preview: PreviewProvider {
+    static var previews: some View {
+        DiaryDetailViewController().showPreview(.iPhone14Pro)
+    }
+}
+#endif

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -152,7 +152,7 @@ final class DiaryDetailViewController: UIViewController {
         [tagView1, tagView2, tagView3].forEach {
             tagViews.append($0)
         }
-        musicContentView.setMusic(title: "Gen Hoshino", artist: "Comedy")
+        musicContentView.setMusic(title: "Comedy", artist: "Gen Hoshino")
     }
     
     

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -19,13 +19,13 @@ final class DiaryDetailViewController: UIViewController {
     let disposeBag = DisposeBag()
 //    private let viewModel: DiaryDetailViewModel
     
-    private let scrollView: UIScrollView = {
+    private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .systemPink
         return scrollView
     }()
     
-    private let stackView: UIStackView = {
+    private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.backgroundColor = .systemYellow
@@ -33,27 +33,27 @@ final class DiaryDetailViewController: UIViewController {
         return stackView
     }()
     
-    private let dateLabel: UILabel = {
+    private lazy var dateLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 20, weight: .light)
         label.backgroundColor = #colorLiteral(red: 0.2745098174, green: 0.4862745106, blue: 0.1411764771, alpha: 1)
         return label
     }()
     
-    private let titleLabel: UILabel = {
+    private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 30, weight: .bold)
         label.backgroundColor = #colorLiteral(red: 0.3647058904, green: 0.06666667014, blue: 0.9686274529, alpha: 1)
         return label
     }()
     
-    private let tagScrollView: UIScrollView = {
+    private lazy var tagScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .systemMint
         return scrollView
     }()
     
-    private let tagStackView: UIStackView = {
+    private lazy var tagStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.backgroundColor = .systemBrown
@@ -61,15 +61,15 @@ final class DiaryDetailViewController: UIViewController {
         return stackView
     }()
     
-    private var tagViews: [UIView] = []
+    private lazy var tagViews: [UIView] = []
     
-    private let imageView: UIImageView = {
+    private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .systemBlue
         return imageView
     }()
     
-    private let textView: UITextView = {
+    private lazy var textView: UITextView = {
         let textView = UITextView()
         textView.backgroundColor = .systemGray5
         textView.text = Metric.textViewPlaceHolder
@@ -78,13 +78,13 @@ final class DiaryDetailViewController: UIViewController {
         return textView
     }()
     
-    private let musicContentView: MusicContentView = {
+    private lazy var musicContentView: MusicContentView = {
         let musicContentView = MusicContentView()
         musicContentView.backgroundColor = .systemGreen
         return musicContentView
     }()
     
-    private let locationContentView: LocationContentView = {
+    private lazy var locationContentView: LocationContentView = {
         let locationContentView = LocationContentView()
         locationContentView.backgroundColor = .orange
         return locationContentView
@@ -139,7 +139,7 @@ final class DiaryDetailViewController: UIViewController {
         textView.delegate = self
         textView.snp.makeConstraints {
             $0.width.equalTo(view.snp.width)
-            $0.height.equalTo(200)
+            $0.height.equalTo(100)
         }
         
         musicContentView.snp.makeConstraints {

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -33,7 +33,7 @@ final class DiaryDetailViewController: UIViewController {
         return stackView
     }()
     
-    private let datelabel: UILabel = {
+    private let dateLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 20, weight: .light)
         label.backgroundColor = #colorLiteral(red: 0.2745098174, green: 0.4862745106, blue: 0.1411764771, alpha: 1)
@@ -92,7 +92,7 @@ final class DiaryDetailViewController: UIViewController {
     private func setupLayout() {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
-        [datelabel, titleLabel, tagScrollView, imageView, textView].forEach {
+        [dateLabel, titleLabel, tagScrollView, imageView, textView].forEach {
             stackView.addArrangedSubview($0)
         }
         tagScrollView.addSubview(tagStackView)
@@ -132,7 +132,7 @@ final class DiaryDetailViewController: UIViewController {
     }
     
     private func setTemporaryData() {
-        datelabel.text = "11월 22일 14:54"
+        dateLabel.text = "11월 22일 14:54"
         titleLabel.text = "서현에서"
         
         let tagView1 = TagView(tagTitle: "음악")


### PR DESCRIPTION
11/22 #71 

## 작업한 내용
### 스크롤뷰 및 스택뷰를 이용하여 레이아웃 구성
- TagView는 스크롤뷰와 horizontal 방향의 스택뷰를 이용하여 구현하였습니다.
- 음악 컨텐츠를 표시하기 위한 MusicContentView를 생성했습니다. 네이밍의 변화가 필요한 경우 자유롭게 이야기 해주셔도 됩니다.
- 커밋 내역 중 옥의 티가 존재하는 점 사과드립니다. 🙇🏻‍♂️
- preview 확인을 위해 SwiftUI를 활용하였습니다. 추후 제거 예정입니다.
- 킹받는 색상으로 제작하였습니다.

<img width="362" alt="스크린샷 2022-11-23 오후 2 02 45" src="https://user-images.githubusercontent.com/29617557/203472720-a4cca4ad-be4b-4aae-9fc9-6216caec7535.png">

## 고민한 점 및 어려웠던 점
### 간헐적으로 preview에 오류가 뜨거나, 아예 뜨지 않는 문제가 있었습니다.
- 오류가 뜨는 문제는 런타임에서 레이아웃 관련 문제로 인한 것이었습니다. 
- 아예 뜨지 않는 문제는 `Option + Command + Enter` 입력하니 해결되었습니다.