### PR TITLE
일기 목록에서 셀 선택시 일기 상세 화면으로 연결

### DIFF
--- a/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
@@ -17,6 +17,16 @@ final class DiaryCoordinator: Coordinator {
     
     func start() {
         let vc = DiaryCollectionViewController()
+        vc.delegate = self
         self.navigationController.pushViewController(vc, animated: true)
+    }
+}
+
+extension DiaryCoordinator: DiaryCollectionViewDelegate {
+    func diaryCellSelected(id: String) {
+        // TODO: id 사용하여 DiaryDetailViewController에 전달하기
+        // ex) let vc = DiaryDetailViewController(viewModel: DiaryDetailViewModel(itemIdentifier: id))
+        let vc = DiaryDetailViewController()
+        navigationController.pushViewController(vc, animated: true)
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -11,6 +11,10 @@ import RxCocoa
 import RxSwift
 import SnapKit
 
+protocol DiaryCollectionViewDelegate: AnyObject {
+    func diaryCellSelected(id: String)
+}
+
 final class DiaryCollectionViewController: UIViewController {
     typealias DataSource = UICollectionViewDiffableDataSource<Section, DiaryListItem>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, DiaryListItem>
@@ -34,6 +38,7 @@ final class DiaryCollectionViewController: UIViewController {
     private let viewModel: DiaryCollectionViewModel
     private var dataSource: DataSource?
     private var diaryCells: [DiaryListItem] = []
+    weak var delegate: DiaryCollectionViewDelegate?
     
     lazy var searchBar: UISearchBar = {
         let bar = UISearchBar()
@@ -179,6 +184,12 @@ extension DiaryCollectionViewController {
         snapshot.appendItems(models)
         
         dataSource?.apply(snapshot)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let id = dataSource?.itemIdentifier(for: indexPath)?.id else { return }
+        
+        delegate?.diaryCellSelected(id: id)
     }
 }
 


### PR DESCRIPTION
11/23 #80 

## 작업한 내용
### 일기 목록에서 셀 선택시 일기 상세 화면으로 연결
- DiaryCollectionViewController에서 셀 선택시 Coordinator에게 알려서 DiaryDetailViewController로 연결
- TODO로 두었듯이, 아직 DiaryDetailViewController에서 ViewModel 등이 구현되지 않아 우선 ViewContoller를 띄워주기만 함