### PR TITLE
DiaryDetailViewController  레이아웃 수정

### DIFF
--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -10,17 +10,22 @@ import UIKit
 import SnapKit
 
 final class LocationContentView: UIView {
+    private enum Metric {
+        static let fontSize: CGFloat = 16
+        static let spacing: CGFloat = 10
+        static let mapButtonSize: CGFloat = 30
+    }
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16, weight: .bold)
+        label.font = .appFont(.surround, size: Metric.fontSize)
         label.text = "위치"
         return label
     }()
     
     private lazy var locationLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16)
+        label.font = .appFont(.surroundAir, size: Metric.fontSize)
         return label
     }()
     
@@ -48,18 +53,18 @@ final class LocationContentView: UIView {
         
         titleLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().offset(10)
+            $0.leading.equalToSuperview().offset(Metric.spacing)
         }
         
         locationLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(titleLabel.snp.trailing).offset(10)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(Metric.spacing)
         }
         
         mapButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.width.height.equalTo(30)
-            $0.trailing.equalToSuperview().inset(10)
+            $0.width.height.equalTo(Metric.mapButtonSize)
+            $0.trailing.equalToSuperview().inset(Metric.spacing)
         }
     }
     

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -14,12 +14,14 @@ final class MusicContentView: UIView {
         static let fontSize: CGFloat = 16
         static let spacing: CGFloat = 10
         static let albumArtImageViewSize: CGFloat = 30
+        static let albumArtCornerRadius: CGFloat = 5
         static let playButtonSize: CGFloat = 30
     }
     
     private lazy var albumArtImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .systemMint
+        imageView.layer.cornerRadius = Metric.albumArtCornerRadius
         return imageView
     }()
     

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 
 final class MusicContentView: UIView {
@@ -82,9 +83,10 @@ final class MusicContentView: UIView {
         }
     }
     
-    func setMusic(title: String, artist: String) {
+    func setMusic(title: String, artist: String, imageURL: URL) {
         titleLabel.text = title
         artistLabel.text = artist
+        albumArtImageView.kf.setImage(with: imageURL)
     }
 }
 

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -83,10 +83,10 @@ final class MusicContentView: UIView {
         }
     }
     
-    func setMusic(title: String, artist: String, imageURL: URL) {
-        titleLabel.text = title
-        artistLabel.text = artist
-        albumArtImageView.kf.setImage(with: imageURL)
+    func setMusic(info: MusicInfo) {
+        titleLabel.text = info.title
+        artistLabel.text = info.artist
+        albumArtImageView.kf.setImage(with: info.imageURL)
     }
 }
 

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -10,6 +10,13 @@ import UIKit
 import SnapKit
 
 final class MusicContentView: UIView {
+    private enum Metric {
+        static let fontSize: CGFloat = 16
+        static let spacing: CGFloat = 10
+        static let albumArtImageViewSize: CGFloat = 30
+        static let playButtonSize: CGFloat = 30
+    }
+    
     private lazy var albumArtImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .systemMint
@@ -18,13 +25,13 @@ final class MusicContentView: UIView {
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16, weight: .bold)
+        label.font = .appFont(.surround, size: Metric.fontSize)
         return label
     }()
     
     private lazy var artistLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16)
+        label.font = .appFont(.surroundAir, size: Metric.fontSize)
         return label
     }()
     
@@ -51,25 +58,25 @@ final class MusicContentView: UIView {
         }
         
         albumArtImageView.snp.makeConstraints {
-            $0.width.height.equalTo(30)
+            $0.width.height.equalTo(Metric.albumArtImageViewSize)
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(16)
+            $0.leading.equalTo(Metric.spacing)
         }
         
         titleLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(albumArtImageView.snp.trailing).offset(10)
+            $0.leading.equalTo(albumArtImageView.snp.trailing).offset(Metric.spacing)
         }
         
         artistLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(titleLabel.snp.trailing).offset(10)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(Metric.spacing)
         }
         
         playButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.width.height.equalTo(30)
-            $0.trailing.equalToSuperview().inset(10)
+            $0.width.height.equalTo(Metric.playButtonSize)
+            $0.trailing.equalToSuperview().inset(Metric.spacing)
         }
     }
     

--- a/Segno/Segno/Presentation/View/TagView.swift
+++ b/Segno/Segno/Presentation/View/TagView.swift
@@ -10,7 +10,9 @@ import SnapKit
 
 final class TagView: UIView {
     private enum Metric {
-        static let tagFontSize: CGFloat = 16
+        static let tagFontSize: CGFloat = 12
+        static let tagInset: CGFloat = 9
+        static let cornerRadius: CGFloat = 15
     }
 
     private lazy var tagLabel: UILabel = {
@@ -33,10 +35,13 @@ final class TagView: UIView {
     private func setupLayout(tagTitle: String) {
         addSubview(tagLabel)
         backgroundColor = .appColor(.color3)
+        layer.cornerRadius = Metric.cornerRadius
+        
         tagLabel.text = tagTitle
         tagLabel.snp.makeConstraints {
-            $0.width.equalTo(self.snp.width)
+            $0.edges.equalToSuperview().inset(Metric.tagInset)
             $0.centerY.equalTo(self.snp.centerY)
         }
+        
     }
 }

--- a/Segno/Segno/Presentation/View/TagView.swift
+++ b/Segno/Segno/Presentation/View/TagView.swift
@@ -9,10 +9,14 @@ import UIKit
 import SnapKit
 
 final class TagView: UIView {
+    private enum Metric {
+        static let tagFontSize: CGFloat = 16
+    }
 
     private lazy var tagLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16)
+        label.font = .appFont(.surround, size: Metric.tagFontSize)
+        label.textColor = .appColor(.white)
         return label
     }()
     
@@ -28,11 +32,11 @@ final class TagView: UIView {
     
     private func setupLayout(tagTitle: String) {
         addSubview(tagLabel)
+        backgroundColor = .appColor(.color3)
         tagLabel.text = tagTitle
         tagLabel.snp.makeConstraints {
             $0.width.equalTo(self.snp.width)
             $0.centerY.equalTo(self.snp.centerY)
         }
-        backgroundColor = .systemPurple
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -15,6 +15,7 @@ final class DiaryDetailViewController: UIViewController {
     private enum Metric {
         static let textViewPlaceHolder: String = "내용을 입력하세요."
         static let stackViewSpacing: CGFloat = 10
+        static let stackViewInset: CGFloat = 16
         static let dateFontSize: CGFloat = 17
         static let titleFontSize: CGFloat = 20
         static let textViewFontSize: CGFloat = 16
@@ -113,8 +114,8 @@ final class DiaryDetailViewController: UIViewController {
         }
         
         stackView.snp.makeConstraints {
-            $0.edges.equalTo(scrollView)
-            $0.width.equalTo(scrollView.snp.width)
+            $0.edges.equalTo(scrollView).inset(Metric.stackViewInset)
+            $0.width.equalTo(scrollView.snp.width).inset(Metric.stackViewInset)
         }
         
         [dateLabel, titleLabel, tagScrollView, imageView, textView, musicContentView, locationContentView].forEach {
@@ -137,23 +138,23 @@ final class DiaryDetailViewController: UIViewController {
         }
         
         imageView.snp.makeConstraints {
-            $0.width.height.equalTo(view.snp.width)
+            $0.width.height.equalTo(stackView.snp.width)
             
         }
         
         textView.delegate = self
         textView.snp.makeConstraints {
-            $0.width.equalTo(view.snp.width)
+            $0.width.equalToSuperview()
             $0.height.equalTo(Metric.textViewHeight)
         }
         
         musicContentView.snp.makeConstraints {
-            $0.width.equalTo(view.snp.width)
+            $0.width.equalToSuperview()
             $0.height.equalTo(Metric.musicContentViewHeight)
         }
         
         locationContentView.snp.makeConstraints {
-            $0.width.equalTo(view.snp.width)
+            $0.width.equalToSuperview()
             $0.height.equalTo(Metric.locationContentViewHeight)
         }
     }

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -205,7 +205,7 @@ final class DiaryDetailViewController: UIViewController {
             .compactMap { $0 }
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] musicInfo in
-                self?.musicContentView.setMusic(title: musicInfo.title, artist: musicInfo.artist, imageURL: musicInfo.imageURL)
+                self?.musicContentView.setMusic(info: musicInfo)
             })
             .disposed(by: disposeBag)
         

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -18,7 +18,7 @@ final class DiaryDetailViewController: UIViewController {
         static let dateFontSize: CGFloat = 17
         static let titleFontSize: CGFloat = 20
         static let textViewFontSize: CGFloat = 16
-        static let textViewHeight: CGFloat = 100
+        static let textViewHeight: CGFloat = 200
         static let textViewInset: CGFloat = 16
         static let tagScrollViewHeight: CGFloat = 30
         static let musicContentViewHeight: CGFloat = 30
@@ -107,15 +107,7 @@ final class DiaryDetailViewController: UIViewController {
         view.backgroundColor = .appColor(.background)
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
-        [dateLabel, titleLabel, tagScrollView, imageView, textView, musicContentView, locationContentView].forEach {
-            stackView.addArrangedSubview($0)
-        }
-        tagScrollView.addSubview(tagStackView)
-        
-        tagViews.forEach {
-            tagStackView.addArrangedSubview($0)
-        }
-        
+
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
@@ -124,6 +116,16 @@ final class DiaryDetailViewController: UIViewController {
             $0.edges.equalTo(scrollView)
             $0.width.equalTo(scrollView.snp.width)
         }
+        
+        [dateLabel, titleLabel, tagScrollView, imageView, textView, musicContentView, locationContentView].forEach {
+            stackView.addArrangedSubview($0)
+        }
+        tagScrollView.addSubview(tagStackView)
+        
+        tagViews.forEach {
+            tagStackView.addArrangedSubview($0)
+        }
+                
         
         tagScrollView.snp.makeConstraints {
             $0.height.equalTo(Metric.tagScrollViewHeight)
@@ -157,12 +159,12 @@ final class DiaryDetailViewController: UIViewController {
     }
     
     private func setTemporaryData() {
-        dateLabel.text = "11월 22일 14:54"
+        dateLabel.text = "11/22 14:54"
         titleLabel.text = "서현에서"
         
         let tagView1 = TagView(tagTitle: "음악")
         let tagView2 = TagView(tagTitle: "휴식")
-        let tagView3 = TagView(tagTitle: "강릉 여행")
+        let tagView3 = TagView(tagTitle: "코딩코딩")
         [tagView1, tagView2, tagView3].forEach {
             tagViews.append($0)
         }

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -14,6 +14,15 @@ import SnapKit
 final class DiaryDetailViewController: UIViewController {
     private enum Metric {
         static let textViewPlaceHolder: String = "내용을 입력하세요."
+        static let stackViewSpacing: CGFloat = 10
+        static let dateFontSize: CGFloat = 17
+        static let titleFontSize: CGFloat = 20
+        static let textViewFontSize: CGFloat = 16
+        static let textViewHeight: CGFloat = 100
+        static let textViewInset: CGFloat = 16
+        static let tagScrollViewHeight: CGFloat = 30
+        static let musicContentViewHeight: CGFloat = 30
+        static let locationContentViewHeight: CGFloat = 30
     }
     
     let disposeBag = DisposeBag()
@@ -21,43 +30,37 @@ final class DiaryDetailViewController: UIViewController {
     
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        scrollView.backgroundColor = .systemPink
         return scrollView
     }()
     
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.backgroundColor = .systemYellow
-        stackView.spacing = 10
+        stackView.spacing = Metric.stackViewSpacing
         return stackView
     }()
     
     private lazy var dateLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 20, weight: .light)
-        label.backgroundColor = #colorLiteral(red: 0.2745098174, green: 0.4862745106, blue: 0.1411764771, alpha: 1)
+        label.font = .appFont(.surroundAir, size: Metric.dateFontSize)
         return label
     }()
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 30, weight: .bold)
-        label.backgroundColor = #colorLiteral(red: 0.3647058904, green: 0.06666667014, blue: 0.9686274529, alpha: 1)
+        label.font = .appFont(.surround, size: Metric.titleFontSize)
         return label
     }()
     
     private lazy var tagScrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        scrollView.backgroundColor = .systemMint
         return scrollView
     }()
     
     private lazy var tagStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.backgroundColor = .systemBrown
-        stackView.spacing = 20
+        stackView.spacing = Metric.stackViewSpacing
         return stackView
     }()
     
@@ -71,22 +74,21 @@ final class DiaryDetailViewController: UIViewController {
     
     private lazy var textView: UITextView = {
         let textView = UITextView()
-        textView.backgroundColor = .systemGray5
+        textView.backgroundColor = .appColor(.grey1)
         textView.text = Metric.textViewPlaceHolder
-        textView.textColor = .gray
-        textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        textView.font = .appFont(.shiningStar, size: Metric.textViewFontSize)
+        textView.textColor = .appColor(.grey2)
+        textView.textContainerInset = UIEdgeInsets(top: Metric.textViewInset, left: Metric.textViewInset, bottom: Metric.textViewInset, right: Metric.textViewInset)
         return textView
     }()
     
     private lazy var musicContentView: MusicContentView = {
         let musicContentView = MusicContentView()
-        musicContentView.backgroundColor = .systemGreen
         return musicContentView
     }()
     
     private lazy var locationContentView: LocationContentView = {
         let locationContentView = LocationContentView()
-        locationContentView.backgroundColor = .orange
         return locationContentView
     }()
     
@@ -102,6 +104,7 @@ final class DiaryDetailViewController: UIViewController {
     }
     
     private func setupLayout() {
+        view.backgroundColor = .appColor(.background)
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
         [dateLabel, titleLabel, tagScrollView, imageView, textView, musicContentView, locationContentView].forEach {
@@ -123,7 +126,7 @@ final class DiaryDetailViewController: UIViewController {
         }
         
         tagScrollView.snp.makeConstraints {
-            $0.height.equalTo(30)
+            $0.height.equalTo(Metric.tagScrollViewHeight)
         }
         
         tagStackView.snp.makeConstraints {
@@ -139,17 +142,17 @@ final class DiaryDetailViewController: UIViewController {
         textView.delegate = self
         textView.snp.makeConstraints {
             $0.width.equalTo(view.snp.width)
-            $0.height.equalTo(100)
+            $0.height.equalTo(Metric.textViewHeight)
         }
         
         musicContentView.snp.makeConstraints {
             $0.width.equalTo(view.snp.width)
-            $0.height.equalTo(50)
+            $0.height.equalTo(Metric.musicContentViewHeight)
         }
         
         locationContentView.snp.makeConstraints {
             $0.width.equalTo(view.snp.width)
-            $0.height.equalTo(50)
+            $0.height.equalTo(Metric.locationContentViewHeight)
         }
     }
     
@@ -174,14 +177,14 @@ extension DiaryDetailViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.text == Metric.textViewPlaceHolder {
             textView.text = nil
-            textView.textColor = .black
+            textView.textColor = .appColor(.black)
         }
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             textView.text = Metric.textViewPlaceHolder
-            textView.textColor = .gray
+            textView.textColor = .appColor(.grey2)
         }
     }
 }


### PR DESCRIPTION
- 11/23 #71 #75 

## 작업한 내용

### 앱 Asset의 색상과 폰트를 적용하였습니다.
- 앱 내 지정된 색상과 폰트를 활용하였습니다.

### 태그 뷰 레이아웃을 변경했습니다.
- tagLabel에 inset을 부여하여 여백을 설정하고,
- cornerRadius를 깎았습니다.
- 최상위 스크롤뷰 하위에 있는 스택뷰에 Inset을 부여했습니다.
<img width="376" alt="스크린샷 2022-11-23 오후 5 27 49" src="https://user-images.githubusercontent.com/29617557/203500845-33d5eacb-1d71-4ab1-b15d-64599771c5f9.png">

### 뷰모델과 바인딩하였습니다.

## 고민한 점 및 어려웠던 점
### Inset을 지정하는 과정에서 의문인 점이 있었습니다.
<img width="351" alt="스크린샷 2022-11-23 오후 5 29 32" src="https://user-images.githubusercontent.com/29617557/203501084-021919f7-3dfc-4672-b749-b165c1c8d23e.png">
위 이미지는 stackView의 Inset을 16, width의 Inset도 32로 부여한 경우입니다.

```swift
stackView.snp.makeConstraints {
            $0.edges.equalTo(scrollView).inset(16)
            $0.width.equalTo(scrollView.snp.width).inset(32)
}
```

제 판단으로는 stackView의 inset을 좌우 각각 16씩 뺐기 때문에, 정상적으로 width를 설정하려면 scrollView의 width에서 16*2 = 32를 빼야 할 것 같았습니다.
하지만
<img width="376" alt="스크린샷 2022-11-23 오후 5 27 49" src="https://user-images.githubusercontent.com/29617557/203500845-33d5eacb-1d71-4ab1-b15d-64599771c5f9.png">

```swift
stackView.snp.makeConstraints {
            $0.edges.equalTo(scrollView).inset(16)
            $0.width.equalTo(scrollView.snp.width).inset(16)
}

```

위 이미지는 stackView의 Inset을 16, width에도 16을 부여해야지 원하는 레이아웃이 나왔습니다.
일단 원하는 바는 이뤘지만, 머릿속으로 정리되지 않은 부분이라 일단 공유드려봅니다. 더 알아보겠습니다.

### MusicInfo에 album 항목이 필요할지 논의가 필요해 보입니다.
- 일단 뷰컨트롤러에 노래 제목, 아티스트, 앨범 아트 이외의 다른 것까지 띄우기는 공간적인 제약이 있어 album을 활용하지 못할 것 같습니다. 추후 album 프로퍼티가 다른 곳에서 쓰일 수 있다면 유지하고, 그렇지 않다면 album 항목은 지워도 무방할 것 같습니다.

### DiaryDetail 항목에 date를 저장하는 프로퍼티가 없습니다.
- 추가해야 할 듯 싶은데, 관련하여 내일 다시 이야기 나눠보면 될 것 같습니다.
