### PR TITLE
일기 작성 뷰 컨트롤러 레이아웃 작성

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A001E29222C97007D9057 /* NetworkError.swift */; };
 		4F9A00202922337F007D9057 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F317780291BE4710019BDFC /* LoginViewController.swift */; };
 		4F9A00212922338E007D9057 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F31777C291BE4710019BDFC /* AppDelegate.swift */; };
+		4FA05B97292DFCCC00AFB020 /* DiaryEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA05B96292DFCCC00AFB020 /* DiaryEditViewController.swift */; };
 		4FA324262923600C00DB04D5 /* DiaryListDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA324252923600C00DB04D5 /* DiaryListDTO.swift */; };
 		4FA32428292363AB00DB04D5 /* DiaryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA32427292363AA00DB04D5 /* DiaryRepository.swift */; };
 		4FA3242B2923646F00DB04D5 /* DiaryListItemEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA3242A2923646F00DB04D5 /* DiaryListItemEndpoint.swift */; };
@@ -81,6 +82,7 @@
 		4F9A001A292227D7007D9057 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4F9A001C29222B1B007D9057 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		4F9A001E29222C97007D9057 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		4FA05B96292DFCCC00AFB020 /* DiaryEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditViewController.swift; sourceTree = "<group>"; };
 		4FA324252923600C00DB04D5 /* DiaryListDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListDTO.swift; sourceTree = "<group>"; };
 		4FA32427292363AA00DB04D5 /* DiaryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryRepository.swift; sourceTree = "<group>"; };
 		4FA3242A2923646F00DB04D5 /* DiaryListItemEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListItemEndpoint.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 				4F317780291BE4710019BDFC /* LoginViewController.swift */,
 				666E6F8B291CFAC200CECD4B /* DiaryCollectionViewController.swift */,
 				982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */,
+				4FA05B96292DFCCC00AFB020 /* DiaryEditViewController.swift */,
 				666E6F8D291CFADD00CECD4B /* MyPageViewController.swift */,
 			);
 			path = ViewController;
@@ -476,6 +479,7 @@
 				666E6F81291CF49E00CECD4B /* LoginCoordinator.swift in Sources */,
 				666E6F85291CF4AD00CECD4B /* MyPageCoordinator.swift in Sources */,
 				4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */,
+				4FA05B97292DFCCC00AFB020 /* DiaryEditViewController.swift in Sources */,
 				988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */,
 				4FCAC5C2292B5C9000BF9CDD /* LoginSession.swift in Sources */,
 				666E6F7D291CF45600CECD4B /* Coordinator.swift in Sources */,

--- a/Segno/Segno/Data/Repository/DTO/DiaryListDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/DiaryListDTO.swift
@@ -22,18 +22,24 @@ struct DiaryListDTO: Decodable {
 
 struct DiaryListItemDTO: Decodable {
     // TODO: 일단은 다이어리 리스트 아이템과 동일하게 작성. 이후 서버 사이드에 따라 바꾸겠습니다.
-    let id: String
+    let identifier: String
     let title: String
     let thumbnailPath: String
     
+    enum CodingKeys: String, CodingKey {
+        case identifier = "_id"
+        case title
+        case thumbnailPath = "imagePath"
+    }
+    
     #if DEBUG
-    static let exampleData1 = DiaryListItemDTO(id: "asdf", title: "예시 데이터1입니다.", thumbnailPath: "")
-    static let exampleData2 = DiaryListItemDTO(id: "qwer", title: "예시 데이터2입니다.", thumbnailPath: "")
-    static let exampleData3 = DiaryListItemDTO(id: "xzcv", title: "예시 데이터3입니다.", thumbnailPath: "")
-    static let exampleData4 = DiaryListItemDTO(id: "hjkl", title: "예시 데이터4입니다.", thumbnailPath: "")
-    static let exampleData5 = DiaryListItemDTO(id: "sdfg", title: "예시 데이터5입니다.", thumbnailPath: "")
-    static let exampleData6 = DiaryListItemDTO(id: "wert", title: "예시 데이터6입니다.", thumbnailPath: "")
-    static let exampleData7 = DiaryListItemDTO(id: "xcvb", title: "예시 데이터7입니다.", thumbnailPath: "")
-    static let exampleData8 = DiaryListItemDTO(id: "ghjk", title: "예시 데이터8입니다.", thumbnailPath: "")
+    static let exampleData1 = DiaryListItemDTO(identifier: "asdf", title: "예시 데이터1입니다.", thumbnailPath: "")
+    static let exampleData2 = DiaryListItemDTO(identifier: "qwer", title: "예시 데이터2입니다.", thumbnailPath: "")
+    static let exampleData3 = DiaryListItemDTO(identifier: "xzcv", title: "예시 데이터3입니다.", thumbnailPath: "")
+    static let exampleData4 = DiaryListItemDTO(identifier: "hjkl", title: "예시 데이터4입니다.", thumbnailPath: "")
+    static let exampleData5 = DiaryListItemDTO(identifier: "sdfg", title: "예시 데이터5입니다.", thumbnailPath: "")
+    static let exampleData6 = DiaryListItemDTO(identifier: "wert", title: "예시 데이터6입니다.", thumbnailPath: "")
+    static let exampleData7 = DiaryListItemDTO(identifier: "xcvb", title: "예시 데이터7입니다.", thumbnailPath: "")
+    static let exampleData8 = DiaryListItemDTO(identifier: "ghjk", title: "예시 데이터8입니다.", thumbnailPath: "")
     #endif
 }

--- a/Segno/Segno/Domain/UseCase/DiaryListUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/DiaryListUseCase.swift
@@ -23,7 +23,7 @@ final class DiaryListUseCaseImpl: DiaryListUseCase {
         return repository.getDiaryListItem()
             .map {
                 $0.data.map { diaryData in
-                    DiaryListItem(id: diaryData.id, title: diaryData.title, thumbnailPath: diaryData.thumbnailPath)
+                    DiaryListItem(identifier: diaryData.identifier, title: diaryData.title, thumbnailPath: diaryData.thumbnailPath)
                 }
             }
     }

--- a/Segno/Segno/Entity/DiaryDetail.swift
+++ b/Segno/Segno/Entity/DiaryDetail.swift
@@ -9,7 +9,7 @@
 import CoreLocation
 
 struct DiaryDetail {
-    let id: String
+    let identifier: String
     let title: String
     let tags: [String]
     let imagePath: String

--- a/Segno/Segno/Entity/DiaryListItem.swift
+++ b/Segno/Segno/Entity/DiaryListItem.swift
@@ -6,7 +6,7 @@
 //
 
 struct DiaryListItem: Hashable {
-    let id: String
+    let identifier: String
     let title: String
     let thumbnailPath: String
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -14,6 +14,7 @@ import SnapKit
 final class DiaryEditViewController: UIViewController {
     var diaryID: String? = nil
     
+    // TODO: 뷰로부터 적당한 간격 주기
     private lazy var mainScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .systemPink // 테스트용 색상
@@ -24,22 +25,67 @@ final class DiaryEditViewController: UIViewController {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.backgroundColor = .systemGreen // 테스트용 색상
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 8
         return stackView
     }()
     
+    // TODO: 이미지 뷰를 버튼처럼 활용할 수 있도록 액션 연결
     private lazy var titleTextField: UITextField = {
         let textField = UITextField()
-        textField.placeholder = "제목을 입력하세요"
         textField.backgroundColor = .systemGray // 테스트용 색상
+        textField.placeholder = "제목을 입력하세요"
         return textField
     }()
     
+    private lazy var photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "popcorn")
+        imageView.backgroundColor = .systemMint // 테스트용 색상
+        return imageView
+    }()
+    
+    private lazy var bodyTextView: UITextView = {
+        let textView = UITextView()
+        textView.backgroundColor = .systemCyan // 테스트용 색상
+        return textView
+    }()
+    
+    // 태그 스택 뷰 - 태그의 관리를 어떻게 할 것인가? 
+    private lazy var tagScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.backgroundColor = .systemTeal // 테스트용 색상
+        return scrollView
+    }()
+    
+    private lazy var tagStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.alignment = .center
+        stackView.axis = .horizontal
+        stackView.backgroundColor = .systemBrown // 테스트용 색상
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    private lazy var addTagButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .black // 테스트용 색상..?
+        button.layer.cornerRadius = 8
+        button.setTitle("+", for: .normal)
+        return button
+    }()
+    
+    // 음악 검색 버튼과 음악 제목 레이블
+    // 위치 검색 버튼과 위치 레이블
+    
     init(diary: DiaryDetail?) {
+        super.init(nibName: nil, bundle: nil)
+        
         if let diary {
             diaryID = diary.id
+            titleTextField.text = diary.title
         }
-        
-        super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) {
@@ -51,6 +97,8 @@ final class DiaryEditViewController: UIViewController {
         
         setupView()
     }
+    
+    // 내비게이션 바 세팅
     
     private func setupView() {
         view.addSubview(mainScrollView)
@@ -64,10 +112,41 @@ final class DiaryEditViewController: UIViewController {
             $0.width.equalTo(mainScrollView)
         }
         
+        setupContentsStackView()
+    }
+    
+    private func setupContentsStackView() {
         contentsStackView.addArrangedSubview(titleTextField)
         titleTextField.snp.makeConstraints {
+            $0.height.equalTo(60)
+        }
+        
+        contentsStackView.addArrangedSubview(photoImageView)
+        photoImageView.snp.makeConstraints {
+            $0.height.equalTo(400)
+        }
+        
+        contentsStackView.addArrangedSubview(bodyTextView)
+        bodyTextView.snp.makeConstraints {
+            $0.height.equalTo(400)
+        }
+        
+        contentsStackView.addArrangedSubview(tagScrollView)
+        tagScrollView.snp.makeConstraints {
             $0.height.equalTo(30)
         }
+        
+        setupTagScrollView()
+    }
+    
+    private func setupTagScrollView() {
+        tagScrollView.addSubview(tagStackView)
+        tagStackView.snp.makeConstraints {
+            $0.edges.equalTo(tagScrollView)
+            $0.height.equalTo(tagScrollView)
+        }
+        
+        
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -40,7 +40,8 @@ final class DiaryEditViewController: UIViewController {
     
     private lazy var photoImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "popcorn")
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(systemName: "photo")
         imageView.backgroundColor = .systemMint // 테스트용 색상
         return imageView
     }()
@@ -51,7 +52,7 @@ final class DiaryEditViewController: UIViewController {
         return textView
     }()
     
-    // 태그 스택 뷰 - 태그의 관리를 어떻게 할 것인가? 
+    // 태그 스택 뷰 - 태그의 관리를 어떻게 할 것인가?
     private lazy var tagScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .systemTeal // 테스트용 색상
@@ -76,8 +77,51 @@ final class DiaryEditViewController: UIViewController {
         return button
     }()
     
-    // 음악 검색 버튼과 음악 제목 레이블
-    // 위치 검색 버튼과 위치 레이블
+    private lazy var musicStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.backgroundColor = .systemIndigo // 테스트용 색상
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 16
+        return stackView
+    }()
+    
+    private lazy var addMusicButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .black // 테스트용 색상..?
+        button.layer.cornerRadius = 8
+        button.setImage(UIImage(systemName: "music.note"), for: .normal)
+        return button
+    }()
+    
+    private lazy var musicInfoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "지금 이 음악은 뭘까요?"
+        return label
+    }()
+    
+    private lazy var locationStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.backgroundColor = .systemOrange
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 16
+        return stackView
+    }()
+    
+    private lazy var addlocationButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .black // 테스트용 색상..?
+        button.layer.cornerRadius = 8
+        button.setImage(UIImage(systemName: "location.fill"), for: .normal)
+        return button
+    }()
+    
+    private lazy var locationInfoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "여기는 어디인가요?"
+        return label
+    }()
     
     init(diary: DiaryDetail?) {
         super.init(nibName: nil, bundle: nil)
@@ -135,8 +179,19 @@ final class DiaryEditViewController: UIViewController {
         tagScrollView.snp.makeConstraints {
             $0.height.equalTo(30)
         }
-        
         setupTagScrollView()
+        
+        contentsStackView.addArrangedSubview(musicStackView)
+        musicStackView.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+        setupMusicStackView()
+        
+        contentsStackView.addArrangedSubview(locationStackView)
+        locationStackView.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+        setupLocationStackView()
     }
     
     private func setupTagScrollView() {
@@ -146,7 +201,23 @@ final class DiaryEditViewController: UIViewController {
             $0.height.equalTo(tagScrollView)
         }
         
-        
+        tagStackView.addArrangedSubview(addTagButton)
+    }
+    
+    private func setupMusicStackView() {
+        musicStackView.addArrangedSubview(addMusicButton)
+        addMusicButton.snp.makeConstraints {
+            $0.width.equalTo(50)
+        }
+        musicStackView.addArrangedSubview(musicInfoLabel)
+    }
+    
+    private func setupLocationStackView() {
+        locationStackView.addArrangedSubview(addlocationButton)
+        addlocationButton.snp.makeConstraints {
+            $0.width.equalTo(50)
+        }
+        locationStackView.addArrangedSubview(locationInfoLabel)
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -14,7 +14,7 @@ import SnapKit
 final class DiaryEditViewController: UIViewController {
     var diaryID: String? = nil
     
-    // TODO: 뷰로부터 적당한 간격 주기
+    // TODO: 뷰로부터 적당한 간격 주기 (일종의 padding이 필요합니다.)
     private lazy var mainScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .systemPink // 테스트용 색상
@@ -123,6 +123,16 @@ final class DiaryEditViewController: UIViewController {
         return label
     }()
     
+//    private lazy var cancelButton: UIBarButtonItem = {
+//        let barButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: nil)
+//        return barButton
+//    }()
+//
+//    private lazy var saveButton: UIBarButtonItem = {
+//        let barButton = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: nil)
+//        return barButton
+//    }()
+    
     init(diary: DiaryDetail?) {
         super.init(nibName: nil, bundle: nil)
         
@@ -139,10 +149,16 @@ final class DiaryEditViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+//        setupNavigationBar()
         setupView()
     }
     
-    // 내비게이션 바 세팅
+    // TODO: 내비게이션 바 관련 요소는 코디네이터 작업 후 활성화할 계획입니다.
+//    private func setupNavigationBar() {
+//        navigationController?.title = "일기 작성"
+//        navigationItem.leftBarButtonItem = cancelButton
+//        navigationItem.rightBarButtonItem = saveButton
+//    }
     
     private func setupView() {
         view.addSubview(mainScrollView)

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -23,7 +23,7 @@ final class DiaryEditViewController: UIViewController {
         static let tagButtonCornerRadius = CGFloat(tagHeight / 2)
     }
     
-    var diaryID: String?
+//    let viewModel: DiaryEditViewModel
     
     private lazy var mainScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -143,11 +143,17 @@ final class DiaryEditViewController: UIViewController {
 //        return barButton
 //    }()
     
-    init(diary: DiaryDetail?) {
+//    // 뷰 모델이 작성되었을 경우, 위의 뷰 모델 프로퍼티 주석 해제와 함께 사용하면 됩니다.
+//    init(viewModel: DiaryEditViewModel
+//         = DiaryEditViewModel()) {
+//        self.viewModel = viewModel
+//
+//        super.init(nibName: nil, bundle: nil)
+//    }
+    
+    // 뷰 모델이 작성되기 전 임시로 사용하는 이니셜라이저입니다.
+    init() {
         super.init(nibName: nil, bundle: nil)
-        
-        diaryID = diary?.identifier
-        titleTextField.text = diary?.title
     }
     
     required init?(coder: NSCoder) {
@@ -250,7 +256,7 @@ import SwiftUI
 
 struct DiaryEditViewController_Preview: PreviewProvider {
     static var previews: some View {
-        DiaryEditViewController(diary: nil).showPreview(.iPhone14Pro)
+        DiaryEditViewController().showPreview(.iPhone14Pro)
     }
 }
 #endif

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -12,21 +12,32 @@ import RxSwift
 import SnapKit
 
 final class DiaryEditViewController: UIViewController {
-    var diaryID: String? = nil
+    private enum Metric {
+        static let standardSpacing: CGFloat = 8
+        static let doubleSpacing: CGFloat = 16
+        static let majorComponentHeight = 400
+        static let minorComponentHeight = 60
+        static let tagHeight = 30
+        
+        static let buttonCornerRadius = CGFloat(minorComponentHeight / 2)
+        static let tagButtonCornerRadius = CGFloat(tagHeight / 2)
+    }
     
-    // TODO: 뷰로부터 적당한 간격 주기 (일종의 padding이 필요합니다.)
+    var diaryID: String?
+    
     private lazy var mainScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .systemPink // 테스트용 색상
         return scrollView
     }()
     
+    // TODO: 뷰로부터 적당한 간격 주기 (일종의 padding이 필요합니다.)
     private lazy var contentsStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.backgroundColor = .systemGreen // 테스트용 색상
         stackView.distribution = .equalSpacing
-        stackView.spacing = 8
+        stackView.spacing = Metric.standardSpacing
         return stackView
     }()
     
@@ -65,14 +76,14 @@ final class DiaryEditViewController: UIViewController {
         stackView.axis = .horizontal
         stackView.backgroundColor = .systemBrown // 테스트용 색상
         stackView.distribution = .equalSpacing
-        stackView.spacing = 8
+        stackView.spacing = Metric.standardSpacing
         return stackView
     }()
     
     private lazy var addTagButton: UIButton = {
         let button = UIButton()
         button.backgroundColor = .black // 테스트용 색상..?
-        button.layer.cornerRadius = 8
+        button.layer.cornerRadius = Metric.tagButtonCornerRadius
         button.setTitle("+", for: .normal)
         return button
     }()
@@ -82,14 +93,14 @@ final class DiaryEditViewController: UIViewController {
         stackView.axis = .horizontal
         stackView.backgroundColor = .systemIndigo // 테스트용 색상
         stackView.distribution = .equalSpacing
-        stackView.spacing = 16
+        stackView.spacing = Metric.doubleSpacing
         return stackView
     }()
     
     private lazy var addMusicButton: UIButton = {
         let button = UIButton()
         button.backgroundColor = .black // 테스트용 색상..?
-        button.layer.cornerRadius = 8
+        button.layer.cornerRadius = Metric.buttonCornerRadius
         button.setImage(UIImage(systemName: "music.note"), for: .normal)
         return button
     }()
@@ -105,14 +116,14 @@ final class DiaryEditViewController: UIViewController {
         stackView.axis = .horizontal
         stackView.backgroundColor = .systemOrange
         stackView.distribution = .equalSpacing
-        stackView.spacing = 16
+        stackView.spacing = Metric.doubleSpacing
         return stackView
     }()
     
     private lazy var addlocationButton: UIButton = {
         let button = UIButton()
         button.backgroundColor = .black // 테스트용 색상..?
-        button.layer.cornerRadius = 8
+        button.layer.cornerRadius = Metric.buttonCornerRadius
         button.setImage(UIImage(systemName: "location.fill"), for: .normal)
         return button
     }()
@@ -178,34 +189,34 @@ final class DiaryEditViewController: UIViewController {
     private func setupContentsStackView() {
         contentsStackView.addArrangedSubview(titleTextField)
         titleTextField.snp.makeConstraints {
-            $0.height.equalTo(60)
+            $0.height.equalTo(Metric.minorComponentHeight)
         }
         
         contentsStackView.addArrangedSubview(photoImageView)
         photoImageView.snp.makeConstraints {
-            $0.height.equalTo(400)
+            $0.height.equalTo(Metric.majorComponentHeight)
         }
         
         contentsStackView.addArrangedSubview(bodyTextView)
         bodyTextView.snp.makeConstraints {
-            $0.height.equalTo(400)
+            $0.height.equalTo(Metric.majorComponentHeight)
         }
         
         contentsStackView.addArrangedSubview(tagScrollView)
         tagScrollView.snp.makeConstraints {
-            $0.height.equalTo(30)
+            $0.height.equalTo(Metric.tagHeight)
         }
         setupTagScrollView()
         
         contentsStackView.addArrangedSubview(musicStackView)
         musicStackView.snp.makeConstraints {
-            $0.height.equalTo(50)
+            $0.height.equalTo(Metric.minorComponentHeight)
         }
         setupMusicStackView()
         
         contentsStackView.addArrangedSubview(locationStackView)
         locationStackView.snp.makeConstraints {
-            $0.height.equalTo(50)
+            $0.height.equalTo(Metric.minorComponentHeight)
         }
         setupLocationStackView()
     }
@@ -223,7 +234,7 @@ final class DiaryEditViewController: UIViewController {
     private func setupMusicStackView() {
         musicStackView.addArrangedSubview(addMusicButton)
         addMusicButton.snp.makeConstraints {
-            $0.width.equalTo(50)
+            $0.width.equalTo(Metric.minorComponentHeight)
         }
         musicStackView.addArrangedSubview(musicInfoLabel)
     }
@@ -231,7 +242,7 @@ final class DiaryEditViewController: UIViewController {
     private func setupLocationStackView() {
         locationStackView.addArrangedSubview(addlocationButton)
         addlocationButton.snp.makeConstraints {
-            $0.width.equalTo(50)
+            $0.width.equalTo(Metric.minorComponentHeight)
         }
         locationStackView.addArrangedSubview(locationInfoLabel)
     }

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -1,0 +1,82 @@
+//
+//  DiaryEditViewController.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/11/23.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class DiaryEditViewController: UIViewController {
+    var diaryID: String? = nil
+    
+    private lazy var mainScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.backgroundColor = .systemPink // 테스트용 색상
+        return scrollView
+    }()
+    
+    private lazy var contentsStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.backgroundColor = .systemGreen // 테스트용 색상
+        return stackView
+    }()
+    
+    private lazy var titleTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "제목을 입력하세요"
+        textField.backgroundColor = .systemGray // 테스트용 색상
+        return textField
+    }()
+    
+    init(diary: DiaryDetail?) {
+        if let diary {
+            diaryID = diary.id
+        }
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupView()
+    }
+    
+    private func setupView() {
+        view.addSubview(mainScrollView)
+        mainScrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        mainScrollView.addSubview(contentsStackView)
+        contentsStackView.snp.makeConstraints {
+            $0.edges.equalTo(mainScrollView)
+            $0.width.equalTo(mainScrollView)
+        }
+        
+        contentsStackView.addArrangedSubview(titleTextField)
+        titleTextField.snp.makeConstraints {
+            $0.height.equalTo(30)
+        }
+    }
+}
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct DiaryEditViewController_Preview: PreviewProvider {
+    static var previews: some View {
+        DiaryEditViewController(diary: nil).showPreview(.iPhone14Pro)
+    }
+}
+#endif

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -63,7 +63,6 @@ final class DiaryEditViewController: UIViewController {
         return textView
     }()
     
-    // 태그 스택 뷰 - 태그의 관리를 어떻게 할 것인가?
     private lazy var tagScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = .systemTeal // 테스트용 색상
@@ -147,10 +146,8 @@ final class DiaryEditViewController: UIViewController {
     init(diary: DiaryDetail?) {
         super.init(nibName: nil, bundle: nil)
         
-        if let diary {
-            diaryID = diary.id
-            titleTextField.text = diary.title
-        }
+        diaryID = diary?.identifier
+        titleTextField.text = diary?.title
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
11/25 #85

## 작업한 내용
### 일기 작성 뷰 컨트롤러 화면 구성 요소를 세팅했습니다.
- 구성 요소로는 제목 텍스트 필드, 이미지 뷰, 내용 텍스트 뷰, 태그 스크롤 뷰, 음악 버튼과 레이블, 위치 버튼과 레이블이 있습니다.

![화면_기록_2022-11-23_오후_9_33_36_AdobeExpress](https://user-images.githubusercontent.com/80261919/203550521-8fdede53-9af2-499e-ba60-be6de7a8da1d.gif)

## 고민한 점 및 어려웠던 점
### SnapKit의 적용에 어려움을 겪었습니다.
- 특히 버튼을 만들 때 높이와 너비를 같게 만드는 것부터가 어려웠습니다.
- 아직 SnapKit에 익숙하지 않아 벌어진 일이라, 더 공부하면 될 것 같습니다.
### 내비게이션 바가 없어서 어려움을 겪었습니다.
- 내비게이션 아이템을 세팅해주려면 내비게이션 바가 있어야 하는데, 그러려면 내비게이션 컨트롤러가 있어야 합니다.
- 일단은 코디네이터를 거쳐 모달하게 띄워 준다면 내비게이션 바는 생길 것이므로 괜찮습니다.
- 하지만 모달하게 띄울 화면인데 굳이 내비게이션 컨트롤러를 새로 만들어 사용해야 할까? 는 생각해 볼 문제인 것 같습니다.
### 베이스 뷰 컨트롤러의 필요성에 대해 고민했습니다.
- 일기 상세 뷰 컨트롤러에 이미 작성되어 있는 뷰 컨트롤러의 익스텐션 덕에, 작성 뷰에 대한 프리뷰 코드만 넣어 주고 바로 프리뷰를 볼 수 있었습니다.
- 이렇듯 다른 뷰 컨트롤러, 나아가 다른 여러 뷰에서도 사용할 가능성이 있는 코드라면 베이스 뷰 컨트롤러에 모아서 구현하는 것도 좋다고 생각했습니다.
- 나아가 프리뷰를 반환하는 static var도 범용성있게 만들 수는 없을까? 생각했습니다.
