### PR TITLE
DiaryDetailViewModel 작성

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		7918380829233F7100BC6992 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7918380729233F7100BC6992 /* UIButton+.swift */; };
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
 		982A3699292C905300FDC6CF /* DiaryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */; };
+		982B3B7F292E68FB0077A44B /* DiaryDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982B3B7E292E68FB0077A44B /* DiaryDetailViewModel.swift */; };
 		9841D6172925FACC00318EA9 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9841D6162925FACC00318EA9 /* LoginUseCase.swift */; };
 		9841D61B2926131200318EA9 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9841D61A2926131200318EA9 /* LoginViewModel.swift */; };
 		988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414AD2922235B007C9132 /* LocalUtilityRepository.swift */; };
@@ -108,6 +109,7 @@
 		7918380729233F7100BC6992 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewController.swift; sourceTree = "<group>"; };
+		982B3B7E292E68FB0077A44B /* DiaryDetailViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewModel.swift; sourceTree = "<group>"; };
 		9841D6162925FACC00318EA9 /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
 		9841D61A2926131200318EA9 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		988414AD2922235B007C9132 /* LocalUtilityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUtilityRepository.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 			isa = PBXGroup;
 			children = (
 				9841D61A2926131200318EA9 /* LoginViewModel.swift */,
+				982B3B7E292E68FB0077A44B /* DiaryDetailViewModel.swift */,
 				988414D829235345007C9132 /* DiaryCollectionViewModel.swift */,
 			);
 			path = ViewModel;
@@ -477,6 +480,7 @@
 				666E6F85291CF4AD00CECD4B /* MyPageCoordinator.swift in Sources */,
 				4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */,
 				988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */,
+				982B3B7F292E68FB0077A44B /* DiaryDetailViewModel.swift in Sources */,
 				4FCAC5C2292B5C9000BF9CDD /* LoginSession.swift in Sources */,
 				666E6F7D291CF45600CECD4B /* Coordinator.swift in Sources */,
 				982A3699292C905300FDC6CF /* DiaryDetailViewController.swift in Sources */,

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  DiaryDetailViewModel.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/23.
+//
+
+import Foundation
+
+import RxSwift
+
+final class DiaryDetailViewModel {
+    
+    private let itemIdentifier: String
+    let useCase: DiaryDetailUseCase
+    var diaryItem = PublishSubject<DiaryDetail>()
+    // TODO: DiaryDetail에 date 추가
+    // lazy var dateObservable = diaryItem.map { $0.date }
+    lazy var titleObservable = diaryItem.map { $0.title }
+    lazy var tagsObservable = diaryItem.map { $0.tags }
+    lazy var imagePathObservable = diaryItem.map { $0.imagePath }
+    lazy var bodyObservable = diaryItem.map { $0.bodyText }
+    lazy var musicObservable = diaryItem.map { $0.musicInfo }
+    lazy var locationObservable = diaryItem.map { diaryDetail in
+        // TODO: CLLocation을 API를 이용하여 주소로 반환하는 로직 작성
+//        $0.location
+        return "경기도 수원시 영통구 반달로"
+    }
+    private let disposeBag = DisposeBag()
+    
+    init(itemIdentifier: String, useCase: DiaryDetailUseCase = DiaryDetailUseCaseImpl()) {
+        self.itemIdentifier = itemIdentifier
+        self.useCase = useCase
+    }
+    
+    func getDiary() {
+        useCase.getDiary(id: itemIdentifier)
+            .subscribe(onSuccess: { [weak self] diary in
+                self?.diaryItem.onNext(diary)
+            }, onFailure: { error in
+                print(error.localizedDescription)
+            }).disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
11/23 #89 

## 작업한 내용
### getDiary 메서드를 추가했습니다.
- 유즈케이스의 getDiary(id:) 메서드를 호출하여 DiaryDetail을 받아 이를 PublishSubject 타입의 diaryItem에 넣어줍니다.
### DiaryDetailViewController에서 바인딩을 위해 각 UI 요소들에 대한 옵저버블을 생성했습니다.
- diaryItem를 매핑하여 생성하였습니다.

## 고민한 점 및 어려웠던 점
### UI 요소 각각에 대한 옵저버블을 생성하는게 나을지, 아니면 뷰모델에선 하나의 PublishSubject만 들고 있고 뷰컨트롤러에서 이를 일일이 분리하여 UI 요소에 바인딩할 지 고민했습니다.
- 후자의 경우, viewModel.diaryItem을 처리하는 로직이 매우 길어질 것이라 예상되어 전자의 방법으로 작성했습니다.