### PR TITLE
일기 작성 뷰 컨트롤러 디자인 조정

### DIFF
--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -39,6 +39,7 @@ final class DiaryEditViewController: UIViewController {
     }
     
 //    let viewModel: DiaryEditViewModel
+    private var disposeBag = DisposeBag()
     
     private lazy var mainScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -161,6 +162,8 @@ final class DiaryEditViewController: UIViewController {
         return button
     }()
     
+    private lazy var tapGesture = UITapGestureRecognizer()
+    
 //    // 뷰 모델이 작성되었을 경우, 위의 뷰 모델 프로퍼티 주석 해제와 함께 사용하면 됩니다.
 //    init(viewModel: DiaryEditViewModel
 //         = DiaryEditViewModel()) {
@@ -182,6 +185,7 @@ final class DiaryEditViewController: UIViewController {
         super.viewDidLoad()
         
         setupView()
+        bindImageView()
     }
     
     private func setupView() {
@@ -208,6 +212,7 @@ final class DiaryEditViewController: UIViewController {
         }
         
         contentsStackView.addArrangedSubview(photoImageView)
+        photoImageView.addGestureRecognizer(tapGesture)
         photoImageView.snp.makeConstraints {
             $0.height.equalTo(Metric.majorContentHeight)
         }
@@ -262,6 +267,14 @@ final class DiaryEditViewController: UIViewController {
             $0.width.equalTo(Metric.minorContentHeight)
         }
         locationStackView.addArrangedSubview(locationInfoLabel)
+    }
+    
+    private func bindImageView() {
+        tapGesture.rx.event
+            .bind(onNext: { recognizer in
+                print("gestures: \(recognizer.numberOfTouches)")
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -15,12 +15,26 @@ final class DiaryEditViewController: UIViewController {
     private enum Metric {
         static let standardSpacing: CGFloat = 8
         static let doubleSpacing: CGFloat = 16
-        static let majorComponentHeight = 400
-        static let minorComponentHeight = 60
-        static let tagHeight = 30
         
-        static let buttonCornerRadius = CGFloat(minorComponentHeight / 2)
-        static let tagButtonCornerRadius = CGFloat(tagHeight / 2)
+        static let majorContentHeight: CGFloat = 400
+        static let minorContentHeight: CGFloat = 60
+        static let halfMinorContentHeight: CGFloat = 30
+        
+        static let stackViewInset: CGFloat = 16
+        static let standardCornerRadius: CGFloat = 8
+        static let mediumFontSize: CGFloat = 24
+        static let smallFontSize: CGFloat = 16
+        
+        static let titlePlaceholder = "제목을 입력하세요."
+        static let musicPlaceholder = "지금 이 음악은 뭘까요?"
+        static let locationPlaceholder = "여기는 어디인가요?"
+        
+        static let imageViewStockImage = UIImage(systemName: "photo")
+        static let musicButtonImage = UIImage(systemName: "music.note")
+        static let locationButtonImage = UIImage(systemName: "location.fill")
+        
+        static let buttonCornerRadius = CGFloat(minorContentHeight / 2)
+        static let tagButtonCornerRadius = CGFloat(halfMinorContentHeight / 2)
     }
     
 //    let viewModel: DiaryEditViewModel
@@ -31,7 +45,6 @@ final class DiaryEditViewController: UIViewController {
         return scrollView
     }()
     
-    // TODO: 뷰로부터 적당한 간격 주기 (일종의 padding이 필요합니다.)
     private lazy var contentsStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -45,21 +58,25 @@ final class DiaryEditViewController: UIViewController {
     private lazy var titleTextField: UITextField = {
         let textField = UITextField()
         textField.backgroundColor = .systemGray // 테스트용 색상
-        textField.placeholder = "제목을 입력하세요"
+        textField.font = .appFont(.surroundAir, size: Metric.mediumFontSize)
+        textField.placeholder = Metric.titlePlaceholder
         return textField
     }()
     
     private lazy var photoImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.backgroundColor = .appColor(.color4)
         imageView.contentMode = .scaleAspectFit
-        imageView.image = UIImage(systemName: "photo")
-        imageView.backgroundColor = .systemMint // 테스트용 색상
+        imageView.image = Metric.imageViewStockImage
+        imageView.layer.cornerRadius = Metric.standardCornerRadius
         return imageView
     }()
     
     private lazy var bodyTextView: UITextView = {
         let textView = UITextView()
         textView.backgroundColor = .systemCyan // 테스트용 색상
+        textView.font = .appFont(.shiningStar, size: Metric.mediumFontSize)
+        textView.layer.cornerRadius = Metric.standardCornerRadius
         return textView
     }()
     
@@ -100,13 +117,14 @@ final class DiaryEditViewController: UIViewController {
         let button = UIButton()
         button.backgroundColor = .black // 테스트용 색상..?
         button.layer.cornerRadius = Metric.buttonCornerRadius
-        button.setImage(UIImage(systemName: "music.note"), for: .normal)
+        button.setImage(Metric.musicButtonImage, for: .normal)
         return button
     }()
     
     private lazy var musicInfoLabel: UILabel = {
         let label = UILabel()
-        label.text = "지금 이 음악은 뭘까요?"
+        label.font = .appFont(.surroundAir, size: Metric.smallFontSize)
+        label.text = Metric.musicPlaceholder
         return label
     }()
     
@@ -123,13 +141,14 @@ final class DiaryEditViewController: UIViewController {
         let button = UIButton()
         button.backgroundColor = .black // 테스트용 색상..?
         button.layer.cornerRadius = Metric.buttonCornerRadius
-        button.setImage(UIImage(systemName: "location.fill"), for: .normal)
+        button.setImage(Metric.locationButtonImage, for: .normal)
         return button
     }()
     
     private lazy var locationInfoLabel: UILabel = {
         let label = UILabel()
-        label.text = "여기는 어디인가요?"
+        label.font = .appFont(.surroundAir, size: Metric.smallFontSize)
+        label.text = Metric.locationPlaceholder
         return label
     }()
     
@@ -183,7 +202,9 @@ final class DiaryEditViewController: UIViewController {
         mainScrollView.addSubview(contentsStackView)
         contentsStackView.snp.makeConstraints {
             $0.edges.equalTo(mainScrollView)
+                .inset(Metric.stackViewInset)
             $0.width.equalTo(mainScrollView)
+                .inset(Metric.stackViewInset)
         }
         
         setupContentsStackView()
@@ -192,34 +213,34 @@ final class DiaryEditViewController: UIViewController {
     private func setupContentsStackView() {
         contentsStackView.addArrangedSubview(titleTextField)
         titleTextField.snp.makeConstraints {
-            $0.height.equalTo(Metric.minorComponentHeight)
+            $0.height.equalTo(Metric.halfMinorContentHeight)
         }
         
         contentsStackView.addArrangedSubview(photoImageView)
         photoImageView.snp.makeConstraints {
-            $0.height.equalTo(Metric.majorComponentHeight)
+            $0.height.equalTo(Metric.majorContentHeight)
         }
         
         contentsStackView.addArrangedSubview(bodyTextView)
         bodyTextView.snp.makeConstraints {
-            $0.height.equalTo(Metric.majorComponentHeight)
+            $0.height.equalTo(Metric.majorContentHeight)
         }
         
         contentsStackView.addArrangedSubview(tagScrollView)
         tagScrollView.snp.makeConstraints {
-            $0.height.equalTo(Metric.tagHeight)
+            $0.height.equalTo(Metric.halfMinorContentHeight)
         }
         setupTagScrollView()
         
         contentsStackView.addArrangedSubview(musicStackView)
         musicStackView.snp.makeConstraints {
-            $0.height.equalTo(Metric.minorComponentHeight)
+            $0.height.equalTo(Metric.minorContentHeight)
         }
         setupMusicStackView()
         
         contentsStackView.addArrangedSubview(locationStackView)
         locationStackView.snp.makeConstraints {
-            $0.height.equalTo(Metric.minorComponentHeight)
+            $0.height.equalTo(Metric.minorContentHeight)
         }
         setupLocationStackView()
     }
@@ -237,7 +258,7 @@ final class DiaryEditViewController: UIViewController {
     private func setupMusicStackView() {
         musicStackView.addArrangedSubview(addMusicButton)
         addMusicButton.snp.makeConstraints {
-            $0.width.equalTo(Metric.minorComponentHeight)
+            $0.width.equalTo(Metric.minorContentHeight)
         }
         musicStackView.addArrangedSubview(musicInfoLabel)
     }
@@ -245,7 +266,7 @@ final class DiaryEditViewController: UIViewController {
     private func setupLocationStackView() {
         locationStackView.addArrangedSubview(addlocationButton)
         addlocationButton.snp.makeConstraints {
-            $0.width.equalTo(Metric.minorComponentHeight)
+            $0.width.equalTo(Metric.minorContentHeight)
         }
         locationStackView.addArrangedSubview(locationInfoLabel)
     }

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -41,14 +41,12 @@ final class DiaryEditViewController: UIViewController {
     
     private lazy var mainScrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        scrollView.backgroundColor = .systemPink // 테스트용 색상
         return scrollView
     }()
     
     private lazy var contentsStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.backgroundColor = .systemGreen // 테스트용 색상
         stackView.distribution = .equalSpacing
         stackView.spacing = Metric.standardSpacing
         return stackView
@@ -57,7 +55,6 @@ final class DiaryEditViewController: UIViewController {
     // TODO: 이미지 뷰를 버튼처럼 활용할 수 있도록 액션 연결
     private lazy var titleTextField: UITextField = {
         let textField = UITextField()
-        textField.backgroundColor = .systemGray // 테스트용 색상
         textField.font = .appFont(.surroundAir, size: Metric.mediumFontSize)
         textField.placeholder = Metric.titlePlaceholder
         return textField
@@ -74,15 +71,16 @@ final class DiaryEditViewController: UIViewController {
     
     private lazy var bodyTextView: UITextView = {
         let textView = UITextView()
-        textView.backgroundColor = .systemCyan // 테스트용 색상
+        textView.backgroundColor = .appColor(.color2)
         textView.font = .appFont(.shiningStar, size: Metric.mediumFontSize)
+        textView.layer.borderColor = UIColor.appColor(.color4)?.cgColor
+        textView.layer.borderWidth = 1
         textView.layer.cornerRadius = Metric.standardCornerRadius
         return textView
     }()
     
     private lazy var tagScrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        scrollView.backgroundColor = .systemTeal // 테스트용 색상
         return scrollView
     }()
     
@@ -90,7 +88,6 @@ final class DiaryEditViewController: UIViewController {
         let stackView = UIStackView()
         stackView.alignment = .center
         stackView.axis = .horizontal
-        stackView.backgroundColor = .systemBrown // 테스트용 색상
         stackView.distribution = .equalSpacing
         stackView.spacing = Metric.standardSpacing
         return stackView
@@ -107,15 +104,16 @@ final class DiaryEditViewController: UIViewController {
     private lazy var musicStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.backgroundColor = .systemIndigo // 테스트용 색상
+        stackView.backgroundColor = .appColor(.color1)
         stackView.distribution = .equalSpacing
+        stackView.layer.cornerRadius = Metric.standardCornerRadius
         stackView.spacing = Metric.doubleSpacing
         return stackView
     }()
     
     private lazy var addMusicButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = .black // 테스트용 색상..?
+        button.backgroundColor = .appColor(.color3)
         button.layer.cornerRadius = Metric.buttonCornerRadius
         button.setImage(Metric.musicButtonImage, for: .normal)
         return button
@@ -131,15 +129,16 @@ final class DiaryEditViewController: UIViewController {
     private lazy var locationStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.backgroundColor = .systemOrange
+        stackView.backgroundColor = .appColor(.color1)
         stackView.distribution = .equalSpacing
+        stackView.layer.cornerRadius = Metric.standardCornerRadius
         stackView.spacing = Metric.doubleSpacing
         return stackView
     }()
     
     private lazy var addlocationButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = .black // 테스트용 색상..?
+        button.backgroundColor = .appColor(.color3) // 테스트용 색상..?
         button.layer.cornerRadius = Metric.buttonCornerRadius
         button.setImage(Metric.locationButtonImage, for: .normal)
         return button
@@ -152,15 +151,14 @@ final class DiaryEditViewController: UIViewController {
         return label
     }()
     
-//    private lazy var cancelButton: UIBarButtonItem = {
-//        let barButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: nil)
-//        return barButton
-//    }()
-//
-//    private lazy var saveButton: UIBarButtonItem = {
-//        let barButton = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: nil)
-//        return barButton
-//    }()
+    private lazy var saveButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("저장", for: .normal)
+        button.layer.cornerRadius = Metric.standardCornerRadius
+        button.titleLabel?.font = .appFont(.surroundAir, size: Metric.smallFontSize)
+        button.backgroundColor = .appColor(.color4)
+        return button
+    }()
     
 //    // 뷰 모델이 작성되었을 경우, 위의 뷰 모델 프로퍼티 주석 해제와 함께 사용하면 됩니다.
 //    init(viewModel: DiaryEditViewModel
@@ -182,16 +180,8 @@ final class DiaryEditViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-//        setupNavigationBar()
         setupView()
     }
-    
-    // TODO: 내비게이션 바 관련 요소는 코디네이터 작업 후 활성화할 계획입니다.
-//    private func setupNavigationBar() {
-//        navigationController?.title = "일기 작성"
-//        navigationItem.leftBarButtonItem = cancelButton
-//        navigationItem.rightBarButtonItem = saveButton
-//    }
     
     private func setupView() {
         view.addSubview(mainScrollView)
@@ -243,6 +233,8 @@ final class DiaryEditViewController: UIViewController {
             $0.height.equalTo(Metric.minorContentHeight)
         }
         setupLocationStackView()
+        
+        contentsStackView.addArrangedSubview(saveButton)
     }
     
     private func setupTagScrollView() {

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -13,26 +13,27 @@ import SnapKit
 
 final class DiaryEditViewController: UIViewController {
     private enum Metric {
+        // 스택 뷰 관련 설정
         static let standardSpacing: CGFloat = 8
         static let doubleSpacing: CGFloat = 16
+        static let stackViewInset: CGFloat = 16
         
+        // 스택 뷰 안에 들어가는 컨텐츠 설정
         static let majorContentHeight: CGFloat = 400
         static let minorContentHeight: CGFloat = 60
         static let halfMinorContentHeight: CGFloat = 30
-        
-        static let stackViewInset: CGFloat = 16
         static let standardCornerRadius: CGFloat = 8
         static let mediumFontSize: CGFloat = 24
         static let smallFontSize: CGFloat = 16
-        
         static let titlePlaceholder = "제목을 입력하세요."
         static let musicPlaceholder = "지금 이 음악은 뭘까요?"
         static let locationPlaceholder = "여기는 어디인가요?"
-        
         static let imageViewStockImage = UIImage(systemName: "photo")
+        
+        // 스택 뷰 안에 들어가는 버튼 설정
         static let musicButtonImage = UIImage(systemName: "music.note")
         static let locationButtonImage = UIImage(systemName: "location.fill")
-        
+        static let saveButtonTitle = "저장"
         static let buttonCornerRadius = CGFloat(minorContentHeight / 2)
         static let tagButtonCornerRadius = CGFloat(halfMinorContentHeight / 2)
     }
@@ -153,10 +154,10 @@ final class DiaryEditViewController: UIViewController {
     
     private lazy var saveButton: UIButton = {
         let button = UIButton()
-        button.setTitle("저장", for: .normal)
-        button.layer.cornerRadius = Metric.standardCornerRadius
-        button.titleLabel?.font = .appFont(.surroundAir, size: Metric.smallFontSize)
         button.backgroundColor = .appColor(.color4)
+        button.layer.cornerRadius = Metric.standardCornerRadius
+        button.setTitle(Metric.saveButtonTitle, for: .normal)
+        button.titleLabel?.font = .appFont(.surroundAir, size: Metric.smallFontSize)
         return button
     }()
     


### PR DESCRIPTION
11/24 #85 

## 작업한 내용
### 일기 작성 뷰 컨트롤러의 디자인 요소를 세부 조정했습니다.
- 각 컴포넌트의 색상을 조절했습니다.
- 하드 코딩되어 있는 값들은 전부 Metric 네임스페이스로 분리했습니다.
- 전체 뷰로부터 약간의 패딩을 주었습니다.

## 고민한 점 및 어려웠던 점
### 서브뷰를 더하는 과정에서 코드가 너무 길어져서 고민했습니다.
- 주로 스택 뷰에 addArrangedSubview를 하는 과정에서 발생한 문제입니다. 화면이 스택 뷰 + 스크롤 뷰의 형식이다 보니, 자연스럽게 발생하는 문제입니다.
- 이를 위해 UIStackView Extension으로 addArrangedSubviews 메서드를 따로 작성하려고 생각하고 있습니다.
- 하지만 지금의 형식 또한 코드가 위 아래로 길기는 하지만, 무엇을 언제 세팅하는지 보기 좋다는 장점은 있습니다. 그래서 고민 중입니다.
### 유저 경험 측면에서 어떻게 더 개선할지 고민했습니다.
- 당장은 컴포넌트를 세팅했지만, 유저 경험이 불편할 만 한 요소가 있습니다. 음악 버튼이나 위치 버튼의 크기, 너무 가까이 붙어 있는 저장 버튼 등의 요소가 있습니다.