### PR TITLE
DiaryDetailViewController 작업

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		98B5263E292CA46C00446413 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263D292CA46C00446413 /* TagView.swift */; };
 		98B52640292CB92900446413 /* MusicContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263F292CB92900446413 /* MusicContentView.swift */; };
 		98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */; };
+		98FDF8A1292F56580083FA05 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A0292F56580083FA05 /* Location.swift */; };
+		98FDF8A3292F5CCA0083FA05 /* MapKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -127,6 +129,8 @@
 		98B5263D292CA46C00446413 /* TagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagView.swift; sourceTree = "<group>"; };
 		98B5263F292CB92900446413 /* MusicContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicContentView.swift; sourceTree = "<group>"; };
 		98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationContentView.swift; sourceTree = "<group>"; };
+		98FDF8A0292F56580083FA05 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
+		98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +221,7 @@
 				4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */,
 				4FEBFAAE291CF9F300E78139 /* MusicInfo.swift */,
 				4F6F74B0292C9BF3007E7AC1 /* UserInfo.swift */,
+				98FDF8A0292F56580083FA05 /* Location.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -278,6 +283,7 @@
 				982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */,
 				4FA05B96292DFCCC00AFB020 /* DiaryEditViewController.swift */,
 				666E6F8D291CFADD00CECD4B /* MyPageViewController.swift */,
+				98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -504,9 +510,11 @@
 				666E6F83291CF4A600CECD4B /* TabBarCoordinator.swift in Sources */,
 				4F9A001D29222B1B007D9057 /* Endpoint.swift in Sources */,
 				4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */,
+				98FDF8A1292F56580083FA05 /* Location.swift in Sources */,
 				7940FB33292E065F00276EFC /* DiaryDetailUseCase.swift in Sources */,
 				666E6F8E291CFADD00CECD4B /* MyPageViewController.swift in Sources */,
 				4F6F74B1292C9BF3007E7AC1 /* UserInfo.swift in Sources */,
+				98FDF8A3292F5CCA0083FA05 /* MapKitViewController.swift in Sources */,
 				4FA3242B2923646F00DB04D5 /* DiaryListItemEndpoint.swift in Sources */,
 				791837FF292225DC00BC6992 /* UIColor+.swift in Sources */,
 				666E6F7F291CF46800CECD4B /* AppCoordinator.swift in Sources */,

--- a/Segno/Segno/Entity/Location.swift
+++ b/Segno/Segno/Entity/Location.swift
@@ -1,0 +1,13 @@
+//
+//  Location.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/24.
+//
+
+import Foundation
+
+struct Location {
+    let latitude: String
+    let longitude: String
+}

--- a/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
@@ -27,6 +27,14 @@ extension DiaryCoordinator: DiaryCollectionViewDelegate {
         // TODO: id 사용하여 DiaryDetailViewController에 전달하기
         // ex) let vc = DiaryDetailViewController(viewModel: DiaryDetailViewModel(itemIdentifier: id))
         let vc = DiaryDetailViewController(viewModel: DiaryDetailViewModel(itemIdentifier: id))
+        vc.delegate = self
         navigationController.pushViewController(vc, animated: true)
+    }
+}
+
+extension DiaryCoordinator: DiaryDetailViewDelegate {
+    func mapButtonTapped(viewController: UIViewController, location: Location) {
+        let mapKitViewController = MapKitViewController()
+        viewController.present(mapKitViewController, animated: true)
     }
 }

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -5,9 +5,15 @@
 //  Created by YOONJONG on 2022/11/23.
 //
 
+import CoreLocation
 import UIKit
 
+import RxCocoa
 import SnapKit
+
+protocol LocationContentViewDelegate: AnyObject {
+    func mapButtonTapped(location: Location)
+}
 
 final class LocationContentView: UIView {
     private enum Metric {
@@ -15,6 +21,9 @@ final class LocationContentView: UIView {
         static let spacing: CGFloat = 10
         static let mapButtonSize: CGFloat = 30
     }
+    
+    private var location: CLLocation?
+    weak var delegate: LocationContentViewDelegate?
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
@@ -33,8 +42,15 @@ final class LocationContentView: UIView {
         let button = UIButton()
         button.setImage(UIImage(systemName: "map.fill"), for: .normal)
         button.tintColor = .appColor(.black)
+        button.rx.tap
+            .bind { [weak self] in
+                // TODO: CLLocation 변수 location을 Location으로 변환하는 로직 필요. 지금은 임시 데이터 부여
+                let customLocation = Location(latitude: "37.248128", longitude: "127.076597")
+                self?.delegate?.mapButtonTapped(location: customLocation)
+            }
         return button
     }()
+    
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -68,8 +84,10 @@ final class LocationContentView: UIView {
         }
     }
     
-    func setLocation(location: String) {
-        locationLabel.text = location
+    func setLocation(location: CLLocation) {
+        // TODO: titleLabel에 표시하기 위해 CLLocation을 주소 String으로 변환하는 로직 필요
+        
+        self.location = location
     }
 }
 

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -32,7 +32,7 @@ final class LocationContentView: UIView {
     private lazy var mapButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "map.fill"), for: .normal)
-        button.tintColor = .white
+        button.tintColor = .appColor(.black)
         return button
     }()
     

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -41,7 +41,7 @@ final class MusicContentView: UIView {
     private lazy var playButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "play.fill"), for: .normal)
-        button.tintColor = .white
+        button.tintColor = .appColor(.black)
         return button
     }()
     

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -32,6 +32,7 @@ final class DiaryCollectionViewController: UIViewController {
         static let buttonWidthAndHeight: CGFloat = 80
         static let inset: CGFloat = 20
         static let navigationTitleSize: CGFloat = 20
+        static let navigationBackButtonTitleSize: CGFloat = 16
     }
     
     let disposeBag = DisposeBag()
@@ -94,6 +95,12 @@ final class DiaryCollectionViewController: UIViewController {
         navigationController?.navigationBar.titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.appFont(.surround, size: Metric.navigationTitleSize),
             NSAttributedString.Key.foregroundColor: UIColor.appColor(.color4) ?? .red]
+        
+        let backBarButtonItem = UIBarButtonItem(title: "리스트", style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = UIColor.appColor(.color4)
+        backBarButtonItem.setTitleTextAttributes([
+            NSAttributedString.Key.font: UIFont.appFont(.surroundAir, size: Metric.navigationBackButtonTitleSize)], for: .normal)
+        navigationItem.backBarButtonItem = backBarButtonItem
         
         diaryCollectionView.delegate = self
         

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -287,7 +287,7 @@ extension UIViewController {
 #if canImport(SwiftUI) && DEBUG
 import SwiftUI
 
-struct ViewController_Preview: PreviewProvider {
+struct DiaryDetailViewController_Preview: PreviewProvider {
     static var previews: some View {
         DiaryDetailViewController(viewModel: DiaryDetailViewModel(itemIdentifier: "0")).showPreview(.iPhone14Pro)
     }

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -17,12 +17,12 @@ protocol DiaryDetailViewDelegate: AnyObject {
 
 final class DiaryDetailViewController: UIViewController {
     private enum Metric {
-        static let textViewPlaceHolder: String = "내용을 입력하세요."
+        static let textViewPlaceHolder: String = "내용이 없네요"
         static let stackViewSpacing: CGFloat = 10
         static let stackViewInset: CGFloat = 16
         static let dateFontSize: CGFloat = 17
         static let titleFontSize: CGFloat = 20
-        static let textViewFontSize: CGFloat = 16
+        static let textViewFontSize: CGFloat = 20
         static let textViewHeight: CGFloat = 200
         static let textViewInset: CGFloat = 16
         static let tagScrollViewHeight: CGFloat = 30
@@ -83,7 +83,8 @@ final class DiaryDetailViewController: UIViewController {
         textView.backgroundColor = .appColor(.grey1)
         textView.text = Metric.textViewPlaceHolder
         textView.font = .appFont(.shiningStar, size: Metric.textViewFontSize)
-        textView.textColor = .appColor(.grey2)
+        textView.textColor = .appColor(.black)
+        textView.isEditable = false
         textView.textContainerInset = UIEdgeInsets(top: Metric.textViewInset, left: Metric.textViewInset, bottom: Metric.textViewInset, right: Metric.textViewInset)
         return textView
     }()
@@ -160,7 +161,6 @@ final class DiaryDetailViewController: UIViewController {
             
         }
         
-        textView.delegate = self
         textView.snp.makeConstraints {
             $0.width.equalToSuperview()
             $0.height.equalTo(Metric.textViewHeight)
@@ -227,22 +227,6 @@ final class DiaryDetailViewController: UIViewController {
     
     private func getDiary() {
         viewModel.getDiary()
-    }
-}
-
-extension DiaryDetailViewController: UITextViewDelegate {
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.text == Metric.textViewPlaceHolder {
-            textView.text = nil
-            textView.textColor = .appColor(.black)
-        }
-    }
-    
-    func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            textView.text = Metric.textViewPlaceHolder
-            textView.textColor = .appColor(.grey2)
-        }
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -117,6 +117,7 @@ final class DiaryDetailViewController: UIViewController {
     
     private func setupLayout() {
         view.backgroundColor = .appColor(.background)
+        
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
         

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -11,6 +11,10 @@ import RxCocoa
 import RxSwift
 import SnapKit
 
+protocol DiaryDetailViewDelegate: AnyObject {
+    func mapButtonTapped(viewController: UIViewController, location: Location)
+}
+
 final class DiaryDetailViewController: UIViewController {
     private enum Metric {
         static let textViewPlaceHolder: String = "내용을 입력하세요."
@@ -28,6 +32,7 @@ final class DiaryDetailViewController: UIViewController {
     
     private let disposeBag = DisposeBag()
     private let viewModel: DiaryDetailViewModel
+    weak var delegate: DiaryDetailViewDelegate?
     
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -90,6 +95,7 @@ final class DiaryDetailViewController: UIViewController {
     
     private lazy var locationContentView: LocationContentView = {
         let locationContentView = LocationContentView()
+        locationContentView.delegate = self
         return locationContentView
     }()
     
@@ -237,6 +243,12 @@ extension DiaryDetailViewController: UITextViewDelegate {
             textView.text = Metric.textViewPlaceHolder
             textView.textColor = .appColor(.grey2)
         }
+    }
+}
+
+extension DiaryDetailViewController: LocationContentViewDelegate {
+    func mapButtonTapped(location: Location) {
+        delegate?.mapButtonTapped(viewController: self, location: location)
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/MapKitViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/MapKitViewController.swift
@@ -1,0 +1,39 @@
+//
+//  MapKitViewController.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/24.
+//
+
+import UIKit
+
+class MapKitViewController: UIViewController {
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        view.backgroundColor = .systemMint
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -21,11 +21,8 @@ final class DiaryDetailViewModel {
     lazy var imagePathObservable = diaryItem.map { $0.imagePath }
     lazy var bodyObservable = diaryItem.map { $0.bodyText }
     lazy var musicObservable = diaryItem.map { $0.musicInfo }
-    lazy var locationObservable = diaryItem.map { diaryDetail in
-        // TODO: CLLocation을 API를 이용하여 주소로 반환하는 로직 작성
-//        $0.location
-        return "경기도 수원시 영통구 반달로"
-    }
+    lazy var locationObservable = diaryItem.map { $0.location }
+        
     private let disposeBag = DisposeBag()
     
     init(itemIdentifier: String, useCase: DiaryDetailUseCase = DiaryDetailUseCaseImpl()) {


### PR DESCRIPTION
11/24 #71 #74 #89 

## 작업한 내용
### 네비게이션의 뒤로가기 버튼 색상 및 폰트를 변경했습니다.
- DetailCollectionViewController를 건드려야 하는 부분이라 DetailCollectionViewController에서 작업했습니다.
### 위도와 경도 String 저장을 위한 Location 구조체를 만들었습니다.
- CLLocation이 존재함에도 이를 생성한 이유는 Location을 작성한 이유는 고민한 점에 작성했습니다.
### 위치 버튼을 탭했을 때 MapKitViewController를 모달로 불러오게끔 코디네이터에 알리는 기능을 구현했습니다.
### 텍스트뷰를 편집할 수 없도록 수정했습니다.
- 편집을 위해 도입했던 delegate 함수도 제거했습니다.

## 고민한 점 및 어려웠던 점
### DiaryDetail 엔티티의 CLLocation을 델리게이트 함수 및 코디네이터를 경유하여 어떻게 넘겨야 할까 고민했습니다.
- DetailViewController에서 지도 버튼을 누르면 델리게이트 함수 및 코디네이터를 경유하여 위치 데이터를 전달해야 합니다.
- 근데 CLLocation을 직접 전달할 경우, ViewController 및 Coordinator에 까지 `CoreLocation` 을 임포트 해야 하는 문제가 있었습니다. ViewController는 그렇다손 치더라도 Coordinator에 CoreLocation을 임포트하는 것은 선을 넘었죠.
- 따라서 LocationContentView에서 버튼을 tap 할 경우 CLLocation에서 위도 및 경도 정보만 담을 수 있는 Location으로 변환되어 이 정보를 전달하도록 했습니다. 위도와 경도 정보는 String으로 저장되어 Location을 사용하는 곳에서 `CoreLocation`을 임포트 할 필요가 없습니다.
