### PR TITLE
refactor: 구글 로그인 결과를 String 타입의 Observable로 넘기도록 변경

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414DA2923606B007C9132 /* DiaryListUseCase.swift */; };
 		98B5263E292CA46C00446413 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263D292CA46C00446413 /* TagView.swift */; };
 		98B52640292CB92900446413 /* MusicContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263F292CB92900446413 /* MusicContentView.swift */; };
+		98BEE36E2934907700B20143 /* LoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BEE36D2934907700B20143 /* LoginError.swift */; };
 		98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */; };
 		98FDF8A1292F56580083FA05 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A0292F56580083FA05 /* Location.swift */; };
 		98FDF8A3292F5CCA0083FA05 /* MapKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */; };
@@ -131,6 +132,7 @@
 		988414DA2923606B007C9132 /* DiaryListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListUseCase.swift; sourceTree = "<group>"; };
 		98B5263D292CA46C00446413 /* TagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagView.swift; sourceTree = "<group>"; };
 		98B5263F292CB92900446413 /* MusicContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicContentView.swift; sourceTree = "<group>"; };
+		98BEE36D2934907700B20143 /* LoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginError.swift; sourceTree = "<group>"; };
 		98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationContentView.swift; sourceTree = "<group>"; };
 		98FDF8A0292F56580083FA05 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitViewController.swift; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				4F3177A0291BF1810019BDFC /* Repository */,
 				4F31779F291BF1780019BDFC /* Network */,
 				988414D62923304F007C9132 /* KeychainError.swift */,
+				98BEE36D2934907700B20143 /* LoginError.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -528,6 +531,7 @@
 				666E6F7F291CF46800CECD4B /* AppCoordinator.swift in Sources */,
 				9841D61B2926131200318EA9 /* LoginViewModel.swift in Sources */,
 				988414D72923304F007C9132 /* KeychainError.swift in Sources */,
+				98BEE36E2934907700B20143 /* LoginError.swift in Sources */,
 				98B5263E292CA46C00446413 /* TagView.swift in Sources */,
 				7940FB2F292E063100276EFC /* DiaryDetailDTO.swift in Sources */,
 				4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */,

--- a/Segno/Segno/Application/AppCoordinator.swift
+++ b/Segno/Segno/Application/AppCoordinator.swift
@@ -18,9 +18,9 @@ final class AppCoordinator: Coordinator {
     
     func start() {
         // TODO: login이 안되어있으면 LoginCoordinator 실행
-//        startLoginCoordinator()
+        startLoginCoordinator()
         // TODO: login이 되어있으면 TabBarCoordinator 실행
-        startTabBarCoordinator()
+//        startTabBarCoordinator()
     }
     
     func startLoginCoordinator() {

--- a/Segno/Segno/Data/LoginError.swift
+++ b/Segno/Segno/Data/LoginError.swift
@@ -1,0 +1,12 @@
+//
+//  LoginError.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/28.
+//
+
+import Foundation
+
+enum LoginError: Error {
+    case userDataNotFound
+}

--- a/Segno/Segno/Data/Session/LoginSession.swift
+++ b/Segno/Segno/Data/Session/LoginSession.swift
@@ -12,14 +12,12 @@ import GoogleSignIn
 import RxSwift
 
 typealias AppleLoginResult = Result<ASAuthorizationAppleIDCredential, Error>
-typealias GoogleLoginResult = Result<String, Error>
 
 final class LoginSession: NSObject {
     static let shared = LoginSession()
     
     var authorizationController: ASAuthorizationController?
     var appleCredentialResult = PublishSubject<AppleLoginResult>()
-    var googleLoginResult = PublishSubject<GoogleLoginResult>()
     
     private override init() { }
     
@@ -34,28 +32,31 @@ final class LoginSession: NSObject {
         authorizationController?.performRequests()
     }
     
-    func performGoogleLogin(_ presenter: UIViewController) {
-        let signInConfig = GIDConfiguration.init(clientID: "880830660858-2niv4cb94c63omf91uej9f23o7j15n8r.apps.googleusercontent.com")
-        
-        GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: presenter) { user, error in
-            guard error == nil else { return }
-            guard let user = user else { return }
+    func performGoogleLogin(_ presenter: UIViewController) -> Observable<String> {
+        return Observable.create() { emitter in
+            let signInConfig = GIDConfiguration.init(clientID: "880830660858-2niv4cb94c63omf91uej9f23o7j15n8r.apps.googleusercontent.com")
             
-            if let userId = user.userID,                  // For client-side use only!
-               let idToken = user.authentication.idToken, // Safe to send to the server
-               let fullName = user.profile?.name,
-               let givenName = user.profile?.givenName,
-               let familyName = user.profile?.familyName,
-               let email = user.profile?.email {
-                print("Token : \(idToken)")
-                print("User ID : \(userId)")
-                print("User Email : \(email)")
-                print("User Name : \((fullName))")
-                self.googleLoginResult.onNext(.success(email))
-            } else {
-                print("Error : User Data Not Found")
-                // TODO: 커스텀 에러 타입 적용
+            GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: presenter) { user, error in
+                guard error == nil else { return }
+                guard let user = user else { return }
+                
+                if let userId = user.userID,                  // For client-side use only!
+                   let idToken = user.authentication.idToken, // Safe to send to the server
+                   let fullName = user.profile?.name,
+                   let email = user.profile?.email {
+                    debugPrint("Token : \(idToken)")
+                    debugPrint("User ID : \(userId)")
+                    debugPrint("User Email : \(email)")
+                    debugPrint("User Name : \((fullName))")
+                    
+                    emitter.onNext(email)
+                    emitter.onCompleted()
+                } else {
+                    debugPrint("Error : User Data Not Found")
+                    emitter.onError(LoginError.userDataNotFound)
+                }
             }
+            return Disposables.create()
         }
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
@@ -19,28 +19,17 @@ final class LoginViewModel {
     init(useCase: LoginUseCase = LoginUseCaseImpl()) {
         self.useCase = useCase
         
-        bindLoginResult()
+        bindAppleLoginResult()
     }
     
-    private func bindLoginResult() {
+    private func bindAppleLoginResult() {
         session.appleCredentialResult
             .subscribe(onNext: { result in
                 switch result {
                 case .success(let credential):
                     guard let email = self.parseEmailFromJWT(credential.identityToken) else { return }
-                    
+
                     self.signIn(withApple: email)
-                case .failure(let error):
-                    print(error.localizedDescription)
-                }
-            })
-            .disposed(by: disposeBag)
-        
-        session.googleLoginResult
-            .subscribe(onNext: { result in
-                switch result {
-                case .success(let email):
-                    self.signIn(withGoogle: email)
                 case .failure(let error):
                     print(error.localizedDescription)
                 }
@@ -54,6 +43,10 @@ final class LoginViewModel {
     
     func performGoogleLogin(on presenter: UIViewController) {
         session.performGoogleLogin(presenter)
+            .subscribe(onNext: { email in
+                self.signIn(withGoogle: email)
+            })
+            .disposed(by: disposeBag)
     }
     
     func signIn(withApple email: String) {


### PR DESCRIPTION
11/28

## 작업한 내용
### 구글 로그인 결과를 뷰모델에 전달하는 방식 변경
- 구글 로그인 결과를 PublishSubject<Result> 타입이 아닌 Observable<String>으로 변경

## 고민한 점 및 어려웠던 점
### 애플 로그인은 동일한 방식으로 변경하지 못했습니다.
- 애플 로그인 특성 상 델리게이트 함수를 이용해야 했습니다. 이로 인해 Observable을 리턴하는 방식으로 리팩토링 하는 것은 불가능했습니다. 그래서 우선 그대로 놔뒀습니다. 애플 로그인과 구글 로그인이 동일한 방식이 아니라 다소 아쉬웠습니다.
