### PR TITLE
LocalUtilityReposity 리팩토링

### DIFF
--- a/Segno/Segno/Data/Repository/LocalUtilityRepository.swift
+++ b/Segno/Segno/Data/Repository/LocalUtilityRepository.swift
@@ -7,63 +7,56 @@
 
 import Foundation
 
-import RxSwift
-
 protocol LocalUtilityRepository {
-    func createToken(key: Any, token: Any) -> Single<Bool>
-    func getToken(key: Any) -> Single<Any>
-    func deleteToken(key: Any) -> Single<Bool>
+    func createToken(key: Any, token: Any) -> Bool
+    func getToken(key: Any) -> Any?
+    func updateToken(key: Any, token: Any) -> Bool
+    func deleteToken(key: Any) -> Bool
     func setUserDefaults(_ value: Any, forKey defaultsKey: UserDefaultsKey)
     func getUserDefaultsObject(forKey defaultsKey: UserDefaultsKey) -> Any?
 }
 
 final class LocalUtilityRepositoryImpl: LocalUtilityRepository {
-    func createToken(key: Any, token: Any) -> Single<Bool> {
-        return Single.create { single in
-            let token = (token as AnyObject).data(using: String.Encoding.utf8.rawValue)!
-            let addQuery: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrAccount as String: key,
-                kSecValueData as String: token
-            ]
-            
-            let status = SecItemAdd(addQuery as CFDictionary, nil)
-            if status == errSecSuccess {
-                single(.success(true))
-            }
-            else if status == errSecDuplicateItem {
-                single(.failure(KeychainError.duplicatedKey))
-            }
-            else {
-                single(.failure(KeychainError.unhandledError(status: status)))
-            }
-            return Disposables.create()
+    func createToken(key: Any, token: Any) -> Bool {
+        let token = (token as AnyObject).data(using: String.Encoding.utf8.rawValue) as Any
+        let addQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: token
+        ]
+        
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        if status == errSecSuccess { return true }
+        else if status == errSecDuplicateItem {
+            // MARK: 기존에는 Error만 return 해주었지만, Error 출력 후 자체적으로 update까지 진행
+            print(KeychainError.duplicatedKey)
+            return updateToken(key: key, token: token)
         }
+        
+        print(KeychainError.unhandledError(status: status))
+        return false
     }
     
-    func getToken(key: Any) -> Single<Any> {
-        return Single.create { single in
-            let getQuery: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrAccount as String: key,
-                kSecReturnAttributes as String: true,
-                kSecReturnData as String: true
-            ]
-            var item: CFTypeRef?
-            let result = SecItemCopyMatching(getQuery as CFDictionary, &item)
-            if result == errSecSuccess {
-                if let existingItem = item as? [String: Any],
-                   let data = existingItem[kSecValueData as String] as? Data,
-                   let token = String(data: data, encoding: .utf8) {
-                    single(.success(token))
-                } else {
-                    single(.failure(KeychainError.unexpectedToken))
-                }
-            } else {
-                single(.failure(KeychainError.unexpectedToken))
+    func getToken(key: Any) -> Any? {
+        let getQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: true
+        ]
+        
+        var item: CFTypeRef?
+        let result = SecItemCopyMatching(getQuery as CFDictionary, &item)
+        if result == errSecSuccess {
+            if let existingItem = item as? [String: Any],
+               let data = existingItem[kSecValueData as String] as? Data,
+               let token = String(data: data, encoding: .utf8) {
+                return token
             }
-            return Disposables.create()
         }
+        
+        print(KeychainError.unexpectedToken)
+        return nil
     }
     
     func updateToken(key: Any, token: Any) -> Bool {
@@ -71,33 +64,28 @@ final class LocalUtilityRepositoryImpl: LocalUtilityRepository {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key
         ]
+        
         let token = (token as AnyObject).data(using: String.Encoding.utf8.rawValue)!
-        let updateQuery: [String: Any] = [
-            kSecValueData as String: token as Any
-        ]
+        let updateQuery: [String: Any] = [ kSecValueData as String: token as Any ]
         
         let status = SecItemUpdate(prevQuery as CFDictionary, updateQuery as CFDictionary)
-        if status == errSecSuccess {
-            return true
-        } else {
-            return false
-        }
+        if status == errSecSuccess { return true }
+        
+        print(KeychainError.unhandledError(status: status))
+        return false
     }
     
-    func deleteToken(key: Any) -> Single<Bool> {
-        return Single.create { single in
-            let query: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrAccount as String: key
-            ]
-            let status = SecItemDelete(query as CFDictionary)
-            if status == errSecSuccess {
-                single(.success(true))
-            } else {
-                single(.failure(KeychainError.unhandledError(status: status)))
-            }
-            return Disposables.create()
-        }
+    func deleteToken(key: Any) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        if status == errSecSuccess { return true }
+        
+        print(KeychainError.unhandledError(status: status))
+        return false
     }
     
     func setUserDefaults(_ value: Any, forKey defaultsKey: UserDefaultsKey) {


### PR DESCRIPTION
11/28

## 작업한 내용
### LocalUtilityRepository의 반응형 제거
- RxSwift와 관련된 모든 부분을 제거(Single 등)
### key로 email 값을 가져올 필요 없이, 직관적인 "userToken"으로 통일
- KeyChain을 사용하는 전체적인 메소드들에서 key를 parameter로 가져올 필요가 없어짐.