### PR TITLE
애플 인증 관련 요소를 뷰 모델에서 제거

### DIFF
--- a/Segno/Segno/Data/Session/LoginSession.swift
+++ b/Segno/Segno/Data/Session/LoginSession.swift
@@ -11,17 +11,16 @@ import Foundation
 import GoogleSignIn
 import RxSwift
 
-typealias AppleLoginResult = Result<ASAuthorizationAppleIDCredential, Error>
-
 final class LoginSession: NSObject {
-    static let shared = LoginSession()
-    
+    private let presenter: LoginViewController
     var authorizationController: ASAuthorizationController?
-    var appleCredentialResult = PublishSubject<AppleLoginResult>()
+    var appleEmail = PublishSubject<String>()
     
-    private override init() { }
+    init(presenter: LoginViewController) {
+        self.presenter = presenter
+    }
     
-    func performAppleLogin(on presenter: ASAuthorizationControllerPresentationContextProviding) {
+    func performAppleLogin() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]
@@ -32,11 +31,11 @@ final class LoginSession: NSObject {
         authorizationController?.performRequests()
     }
     
-    func performGoogleLogin(_ presenter: UIViewController) -> Observable<String> {
+    func performGoogleLogin() -> Observable<String> {
         return Observable.create() { emitter in
             let signInConfig = GIDConfiguration.init(clientID: "880830660858-2niv4cb94c63omf91uej9f23o7j15n8r.apps.googleusercontent.com")
             
-            GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: presenter) { user, error in
+            GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: self.presenter) { user, error in
                 guard error == nil else { return }
                 guard let user = user else { return }
                 
@@ -63,15 +62,54 @@ final class LoginSession: NSObject {
 
 extension LoginSession: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        guard let auth = authorization.credential as? ASAuthorizationAppleIDCredential else {
+        guard let auth = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let data = auth.identityToken,
+              let email = parseEmailFromJWT(data) else {
+            // TODO: 중간에 데이터를 가져오는 과정 하나라도 실패했을 때 에러 처리
+            debugPrint("데이터를 변환하는 데 실패")
             return
         }
         
-        appleCredentialResult.onNext(.success(auth))
+        appleEmail.onNext(email)
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // TODO: 아예 인증이 안 됐을 때 에러 처리
+        debugPrint("인증 실패")
+    }
+}
+
+extension LoginSession {
+    // MARK: - jwt 해석 메서드
+    func parseEmailFromJWT(_ jwtData: Data?) -> String? {
+        var email: String?
+        guard let jwtData = jwtData,
+              let jwt = String(data: jwtData, encoding: .ascii) else { return nil }
         
-        appleCredentialResult.onNext(.failure(error))
+        // parse body from jwt
+        let jwtElement = jwt.split(separator: ".").map {
+            String($0)
+        }.compactMap {
+            Data(base64Encoded: $0)
+        }
+        
+        guard jwtElement.count != 0 else { return nil }
+        
+        let data = parseBodyFromJWTData(jwtElement)
+        
+        if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any],
+           let emailFromJson = json["email"] as? String {
+            email = emailFromJson
+        }
+        
+        return email
+    }
+    
+    private func parseBodyFromJWTData(_ jwtData: [Data]) -> Data {
+        if jwtData.count > 1 {
+            return jwtData[1]
+        } else {
+            return jwtData[0]
+        }
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/LoginViewModel.swift
@@ -5,50 +5,18 @@
 //  Created by YOONJONG on 2022/11/17.
 //
 
-import AuthenticationServices
-
 import RxSwift
 
 final class LoginViewModel {
     let useCase: LoginUseCase
-    let session = LoginSession.shared
     private let disposeBag = DisposeBag()
     
     var isLoginSucceeded = PublishSubject<Bool>()
     
     init(useCase: LoginUseCase = LoginUseCaseImpl()) {
         self.useCase = useCase
-        
-        bindAppleLoginResult()
     }
-    
-    private func bindAppleLoginResult() {
-        session.appleCredentialResult
-            .subscribe(onNext: { result in
-                switch result {
-                case .success(let credential):
-                    guard let email = self.parseEmailFromJWT(credential.identityToken) else { return }
 
-                    self.signIn(withApple: email)
-                case .failure(let error):
-                    print(error.localizedDescription)
-                }
-            })
-            .disposed(by: disposeBag)
-    }
-    
-    func performAppleLogin(on presenter: ASAuthorizationControllerPresentationContextProviding) {
-        session.performAppleLogin(on: presenter)
-    }
-    
-    func performGoogleLogin(on presenter: UIViewController) {
-        session.performGoogleLogin(presenter)
-            .subscribe(onNext: { email in
-                self.signIn(withGoogle: email)
-            })
-            .disposed(by: disposeBag)
-    }
-    
     func signIn(withApple email: String) {
         useCase.sendLoginRequest(withApple: email)
                 .subscribe(onSuccess: { [weak self] result in
@@ -67,40 +35,5 @@ final class LoginViewModel {
                 self?.isLoginSucceeded.onNext(false)
             })
             .disposed(by: disposeBag)
-    }
-}
-
-extension LoginViewModel {
-    // MARK: - jwt 해석 메서드
-    func parseEmailFromJWT(_ jwtData: Data?) -> String? {
-        var email: String?
-        guard let jwtData = jwtData,
-              let jwt = String(data: jwtData, encoding: .ascii) else { return nil }
-        
-        // parse body from jwt
-        let jwtElement = jwt.split(separator: ".").map {
-            String($0)
-        }.compactMap {
-            Data(base64Encoded: $0)
-        }
-        
-        guard jwtElement.count != 0 else { return nil }
-        
-        let data = parseBodyFromJWTData(jwtElement)
-        
-        if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any],
-           let emailFromJson = json["email"] as? String {
-            email = emailFromJson
-        }
-        
-        return email
-    }
-    
-    private func parseBodyFromJWTData(_ jwtData: [Data]) -> Data {
-        if jwtData.count > 1 {
-            return jwtData[1]
-        } else {
-            return jwtData[0]
-        }
     }
 }


### PR DESCRIPTION
11/29

## 작업한 내용
### 애플 로그인 관련 요소를 뷰 모델에서 분리했습니다.
- 애플 로그인을 위해 import하는 AuthorizationServices에 UI 관련 요소가 들어 있기 때문입니다.
    - 되게 많은데, 대표적으로는 AuthenticationServices.ASAccountAuthenticationModificationViewController 가 있겠습니다.
- 이제 뷰 컨트롤러가 로그인 세션 객체를 들고 있고, 세션에서 인증 과정을 거친 다음 해당 정보를 토대로 자체 서버에 로그인 요청을 보내게 됩니다.
