### PR TITLE
SettingsViewController에서 Cell 내부 액션을 이용하는 방법 변경

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		983AE9D22934F041006547BD /* NicknameCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AE9D12934F041006547BD /* NicknameCell.swift */; };
 		983AE9D4293513AD006547BD /* SettingsCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AE9D3293513AD006547BD /* SettingsCellModel.swift */; };
 		983AE9D6293514E8006547BD /* SettingsActionSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AE9D5293514E8006547BD /* SettingsActionSheetCell.swift */; };
+		983AE9D82935CEE2006547BD /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AE9D72935CEE2006547BD /* SettingsViewModel.swift */; };
 		9841D6172925FACC00318EA9 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9841D6162925FACC00318EA9 /* LoginUseCase.swift */; };
 		9841D61B2926131200318EA9 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9841D61A2926131200318EA9 /* LoginViewModel.swift */; };
 		988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414AD2922235B007C9132 /* LocalUtilityRepository.swift */; };
@@ -70,8 +71,8 @@
 		988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414DA2923606B007C9132 /* DiaryListUseCase.swift */; };
 		98B5263E292CA46C00446413 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263D292CA46C00446413 /* TagView.swift */; };
 		98B52640292CB92900446413 /* MusicContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263F292CB92900446413 /* MusicContentView.swift */; };
-		98BEE3702934A19800B20143 /* SettingsSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BEE36F2934A19800B20143 /* SettingsSwitchCell.swift */; };
 		98BEE36E2934907700B20143 /* LoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BEE36D2934907700B20143 /* LoginError.swift */; };
+		98BEE3702934A19800B20143 /* SettingsSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BEE36F2934A19800B20143 /* SettingsSwitchCell.swift */; };
 		98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */; };
 		98FDF8A1292F56580083FA05 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A0292F56580083FA05 /* Location.swift */; };
 		98FDF8A3292F5CCA0083FA05 /* MapKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */; };
@@ -131,6 +132,7 @@
 		983AE9D12934F041006547BD /* NicknameCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameCell.swift; sourceTree = "<group>"; };
 		983AE9D3293513AD006547BD /* SettingsCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCellModel.swift; sourceTree = "<group>"; };
 		983AE9D5293514E8006547BD /* SettingsActionSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsActionSheetCell.swift; sourceTree = "<group>"; };
+		983AE9D72935CEE2006547BD /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		9841D6162925FACC00318EA9 /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
 		9841D61A2926131200318EA9 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		988414AD2922235B007C9132 /* LocalUtilityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalUtilityRepository.swift; sourceTree = "<group>"; };
@@ -139,8 +141,8 @@
 		988414DA2923606B007C9132 /* DiaryListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListUseCase.swift; sourceTree = "<group>"; };
 		98B5263D292CA46C00446413 /* TagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagView.swift; sourceTree = "<group>"; };
 		98B5263F292CB92900446413 /* MusicContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicContentView.swift; sourceTree = "<group>"; };
-		98BEE36F2934A19800B20143 /* SettingsSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSwitchCell.swift; sourceTree = "<group>"; };
 		98BEE36D2934907700B20143 /* LoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginError.swift; sourceTree = "<group>"; };
+		98BEE36F2934A19800B20143 /* SettingsSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSwitchCell.swift; sourceTree = "<group>"; };
 		98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationContentView.swift; sourceTree = "<group>"; };
 		98FDF8A0292F56580083FA05 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitViewController.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 				9841D61A2926131200318EA9 /* LoginViewModel.swift */,
 				982B3B7E292E68FB0077A44B /* DiaryDetailViewModel.swift */,
 				988414D829235345007C9132 /* DiaryCollectionViewModel.swift */,
+				983AE9D72935CEE2006547BD /* SettingsViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -502,6 +505,7 @@
 				98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */,
 				4F4E0D3E2924B925005ABA8F /* LoginRepository.swift in Sources */,
 				4F9A00212922338E007D9057 /* AppDelegate.swift in Sources */,
+				983AE9D82935CEE2006547BD /* SettingsViewModel.swift in Sources */,
 				66F0D7EE2925FF8B0074872E /* DiaryCell.swift in Sources */,
 				4F9A00202922337F007D9057 /* LoginViewController.swift in Sources */,
 				982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */,
@@ -696,7 +700,7 @@
 				CODE_SIGN_ENTITLEMENTS = Segno/Segno.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = H5UNW2D34P;
+				DEVELOPMENT_TEAM = 4QG3GC35LA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -709,7 +713,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.oldstar.segnobydalsegno;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codershigh.boostcamp.Segno;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -725,7 +729,7 @@
 				CODE_SIGN_ENTITLEMENTS = Segno/Segno.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = H5UNW2D34P;
+				DEVELOPMENT_TEAM = 4QG3GC35LA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -738,7 +742,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.oldstar.segnobydalsegno;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codershigh.boostcamp.Segno;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Segno/Segno/Data/Repository/UserDefaultsKey.swift
+++ b/Segno/Segno/Data/Repository/UserDefaultsKey.swift
@@ -8,4 +8,6 @@
 enum UserDefaultsKey: String {
     case isFirstEntryApp
     case isAutoLogin
+    case isAutoPlayEnabled
+    case darkmode
 }

--- a/Segno/Segno/Presentation/View/NicknameCell.swift
+++ b/Segno/Segno/Presentation/View/NicknameCell.swift
@@ -23,9 +23,8 @@ final class NicknameCell: UITableViewCell {
         static let buttonWidth: CGFloat = 70
     }
     
-    private var viewModel: SettingsViewModel?
     private let disposeBag = DisposeBag()
-    var nicknameChangeSucceeded = PublishSubject<Bool>()
+    var nicknameChangeButtonTapped = PublishSubject<String>()
     
     private lazy var nicknameView: UIView = {
         let view = UIView()
@@ -66,6 +65,7 @@ final class NicknameCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
         setupLayout()
     }
     
@@ -97,18 +97,10 @@ final class NicknameCell: UITableViewCell {
         }
     }
     
-    func configure(viewModel: SettingsViewModel) {
-        self.viewModel = viewModel
-    }
-    
     @objc private func okButtonTapped() {
         debugPrint("\(nicknameTextField.text!) - 확인 버튼을 누름")
-        guard let newNickname = nicknameTextField.text,
-        let viewModel = viewModel else { return }
-        viewModel.changeNickname(to: newNickname)
-            .subscribe(onNext: { [weak self] result in
-                self?.nicknameChangeSucceeded.onNext(result)
-            })
-            .disposed(by: disposeBag)
+        guard let newNickname = nicknameTextField.text else { return }
+        nicknameChangeButtonTapped
+            .onNext(newNickname)
     }
 }

--- a/Segno/Segno/Presentation/View/NicknameCell.swift
+++ b/Segno/Segno/Presentation/View/NicknameCell.swift
@@ -24,8 +24,7 @@ final class NicknameCell: UITableViewCell {
     }
     
     private let disposeBag = DisposeBag()
-    var nicknameChangeButtonTapped = PublishSubject<String>()
-    
+
     private lazy var nicknameView: UIView = {
         let view = UIView()
         return view
@@ -55,7 +54,6 @@ final class NicknameCell: UITableViewCell {
         button.backgroundColor = .appColor(.color4)
         button.setTitleColor(.appColor(.white), for: .normal)
         button.layer.cornerRadius = Metric.cornerRadius
-        button.addTarget(self, action: #selector(okButtonTapped), for: .touchUpInside)
         return button
     }()
     
@@ -95,12 +93,5 @@ final class NicknameCell: UITableViewCell {
             $0.trailing.equalTo(nicknameView).inset(Metric.edgeSpacing)
             $0.height.equalTo(Metric.textHeight)
         }
-    }
-    
-    @objc private func okButtonTapped() {
-        debugPrint("\(nicknameTextField.text!) - 확인 버튼을 누름")
-        guard let newNickname = nicknameTextField.text else { return }
-        nicknameChangeButtonTapped
-            .onNext(newNickname)
     }
 }

--- a/Segno/Segno/Presentation/View/NicknameCell.swift
+++ b/Segno/Segno/Presentation/View/NicknameCell.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxSwift
+
 final class NicknameCell: UITableViewCell {
     private enum Metric {
         static let nicknameLabelText: String = "닉네임 변경"
@@ -20,6 +22,10 @@ final class NicknameCell: UITableViewCell {
         static let nicknameViewHeight: CGFloat = 100
         static let buttonWidth: CGFloat = 70
     }
+    
+    private var viewModel: SettingsViewModel?
+    private let disposeBag = DisposeBag()
+    var nicknameChangeSucceeded = PublishSubject<Bool>()
     
     private lazy var nicknameView: UIView = {
         let view = UIView()
@@ -91,7 +97,18 @@ final class NicknameCell: UITableViewCell {
         }
     }
     
+    func configure(viewModel: SettingsViewModel) {
+        self.viewModel = viewModel
+    }
+    
     @objc private func okButtonTapped() {
         debugPrint("\(nicknameTextField.text!) - 확인 버튼을 누름")
+        guard let newNickname = nicknameTextField.text,
+        let viewModel = viewModel else { return }
+        viewModel.changeNickname(to: newNickname)
+            .subscribe(onNext: { [weak self] result in
+                self?.nicknameChangeSucceeded.onNext(result)
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/Segno/Segno/Presentation/View/SettingsActionSheetCell.swift
+++ b/Segno/Segno/Presentation/View/SettingsActionSheetCell.swift
@@ -20,6 +20,8 @@ final class SettingsActionSheetCell: UITableViewCell {
         static let edgeSpacing: CGFloat = 20
     }
     
+    private var viewModel: SettingsViewModel?
+    
     lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .appFont(.shiningStar, size: Metric.labelFontSize)
@@ -45,14 +47,16 @@ final class SettingsActionSheetCell: UITableViewCell {
         }
     }
     
-    func configure(title: String) {
+    func configure(title: String, viewModel: SettingsViewModel) {
         titleLabel.text = title
+        self.viewModel = viewModel
     }
     
     func tapped(mode: SettingsActionSheetMode) {
         switch mode {
         case .darkmode:
             debugPrint("darkmode 관련 액션을 실행합니다.")
+            viewModel?.changeAutoPlayMode()
         }
     }
 }

--- a/Segno/Segno/Presentation/View/SettingsActionSheetCell.swift
+++ b/Segno/Segno/Presentation/View/SettingsActionSheetCell.swift
@@ -11,19 +11,13 @@ import UIKit
 import RxSwift
 import SnapKit
 
-enum SettingsActionSheetMode {
-    case darkmode
-}
-
 final class SettingsActionSheetCell: UITableViewCell {
     private enum Metric {
         static let labelFontSize: CGFloat = 20
         static let edgeSpacing: CGFloat = 20
     }
     
-    var settingsActionSheetTapped = PublishSubject<(SettingsActionSheetMode, Any?)>()
-    
-    lazy var titleLabel: UILabel = {
+    private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .appFont(.shiningStar, size: Metric.labelFontSize)
         return label
@@ -50,22 +44,5 @@ final class SettingsActionSheetCell: UITableViewCell {
     
     func configure(title: String) {
         titleLabel.text = title
-    }
-    
-    func tapped(mode: SettingsActionSheetMode, _ completionHandler: @escaping (UIAlertController) -> Void) {
-        switch mode {
-        case .darkmode:
-            let actionSheet = UIAlertController(title: "다크 모드 설정", message: nil, preferredStyle: .actionSheet)
-            actionSheet.addAction(UIAlertAction(title: "시스템 설정", style: .default, handler: { _ in
-                self.settingsActionSheetTapped.onNext((.darkmode, 0))
-            }))
-            actionSheet.addAction(UIAlertAction(title: "항상 밝게", style: .default, handler: { _ in
-                self.settingsActionSheetTapped.onNext((.darkmode, 1))
-            }))
-            actionSheet.addAction(UIAlertAction(title: "항상 어둡게", style: .default, handler: { _ in
-                self.settingsActionSheetTapped.onNext((.darkmode, 2))
-            }))
-            completionHandler(actionSheet)
-        }
     }
 }

--- a/Segno/Segno/Presentation/View/SettingsActionSheetCell.swift
+++ b/Segno/Segno/Presentation/View/SettingsActionSheetCell.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+import RxSwift
 import SnapKit
 
 enum SettingsActionSheetMode {
@@ -20,7 +21,7 @@ final class SettingsActionSheetCell: UITableViewCell {
         static let edgeSpacing: CGFloat = 20
     }
     
-    private var viewModel: SettingsViewModel?
+    var settingsActionSheetTapped = PublishSubject<(SettingsActionSheetMode, Any?)>()
     
     lazy var titleLabel: UILabel = {
         let label = UILabel()
@@ -47,16 +48,24 @@ final class SettingsActionSheetCell: UITableViewCell {
         }
     }
     
-    func configure(title: String, viewModel: SettingsViewModel) {
+    func configure(title: String) {
         titleLabel.text = title
-        self.viewModel = viewModel
     }
     
-    func tapped(mode: SettingsActionSheetMode) {
+    func tapped(mode: SettingsActionSheetMode, _ completionHandler: @escaping (UIAlertController) -> Void) {
         switch mode {
         case .darkmode:
-            debugPrint("darkmode 관련 액션을 실행합니다.")
-            viewModel?.changeAutoPlayMode()
+            let actionSheet = UIAlertController(title: "다크 모드 설정", message: nil, preferredStyle: .actionSheet)
+            actionSheet.addAction(UIAlertAction(title: "시스템 설정", style: .default, handler: { _ in
+                self.settingsActionSheetTapped.onNext((.darkmode, 0))
+            }))
+            actionSheet.addAction(UIAlertAction(title: "항상 밝게", style: .default, handler: { _ in
+                self.settingsActionSheetTapped.onNext((.darkmode, 1))
+            }))
+            actionSheet.addAction(UIAlertAction(title: "항상 어둡게", style: .default, handler: { _ in
+                self.settingsActionSheetTapped.onNext((.darkmode, 2))
+            }))
+            completionHandler(actionSheet)
         }
     }
 }

--- a/Segno/Segno/Presentation/View/SettingsSwitchCell.swift
+++ b/Segno/Segno/Presentation/View/SettingsSwitchCell.swift
@@ -15,6 +15,8 @@ final class SettingsSwitchCell: UITableViewCell {
         static let labelFontSize: CGFloat = 20
     }
     
+    private var viewModel: SettingsViewModel?
+    
     lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .appFont(.shiningStar, size: Metric.labelFontSize)
@@ -51,10 +53,11 @@ final class SettingsSwitchCell: UITableViewCell {
         }
     }
     
-    func configure(title: String, isOn: Bool, action: CellActions) {
+    func configure(title: String, isOn: Bool, action: CellActions, viewModel: SettingsViewModel) {
         titleLabel.text = title
         switchButton.isOn = isOn
         switchButton.tag = action.toRow
+        self.viewModel = viewModel
     }
     
     @objc private func switchButtonTapped() {
@@ -62,6 +65,8 @@ final class SettingsSwitchCell: UITableViewCell {
         switch action {
         case .autoplay:
             debugPrint("\(switchButton.isOn) / autoPlay 관련 액션을 실행합니다.")
+            guard let viewModel = viewModel else { return }
+            viewModel.changeAutoPlayMode(to: switchButton.isOn)
         default:
             break
         }

--- a/Segno/Segno/Presentation/View/SettingsSwitchCell.swift
+++ b/Segno/Segno/Presentation/View/SettingsSwitchCell.swift
@@ -51,15 +51,16 @@ final class SettingsSwitchCell: UITableViewCell {
         }
     }
     
-    func configure(title: String, isOn: Bool, row: Int) {
+    func configure(title: String, isOn: Bool, action: CellActions) {
         titleLabel.text = title
         switchButton.isOn = isOn
-        switchButton.tag = row
+        switchButton.tag = action.toRow
     }
     
     @objc private func switchButtonTapped() {
-        switch switchButton.tag {
-        case 1:
+        let action = CellActions(rawValue: switchButton.tag)
+        switch action {
+        case .autoplay:
             debugPrint("\(switchButton.isOn) / autoPlay 관련 액션을 실행합니다.")
         default:
             break

--- a/Segno/Segno/Presentation/View/SettingsSwitchCell.swift
+++ b/Segno/Segno/Presentation/View/SettingsSwitchCell.swift
@@ -16,9 +16,7 @@ final class SettingsSwitchCell: UITableViewCell {
         static let labelFontSize: CGFloat = 20
     }
     
-    var settingsSwitchTapped = PublishSubject<(CellActions, Any?)>()
-    
-    lazy var titleLabel: UILabel = {
+    private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .appFont(.shiningStar, size: Metric.labelFontSize)
         return label
@@ -26,7 +24,6 @@ final class SettingsSwitchCell: UITableViewCell {
     
     lazy var switchButton: UISwitch = {
         let switchButton = UISwitch()
-        switchButton.addTarget(self, action: #selector(switchButtonTapped), for: .touchUpInside)
         return switchButton
     }()
     
@@ -58,17 +55,5 @@ final class SettingsSwitchCell: UITableViewCell {
         titleLabel.text = title
         switchButton.isOn = isOn
         switchButton.tag = action.toRow
-    }
-    
-    @objc private func switchButtonTapped() {
-        guard let action = CellActions(rawValue: switchButton.tag) else { return }
-        let switchStatus = switchButton.isOn
-        switch action {
-        case .autoplay:
-            settingsSwitchTapped
-                .onNext((action, switchStatus))
-        default:
-            break
-        }
     }
 }

--- a/Segno/Segno/Presentation/View/SettingsSwitchCell.swift
+++ b/Segno/Segno/Presentation/View/SettingsSwitchCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import RxSwift
 import SnapKit
 
 final class SettingsSwitchCell: UITableViewCell {
@@ -15,7 +16,7 @@ final class SettingsSwitchCell: UITableViewCell {
         static let labelFontSize: CGFloat = 20
     }
     
-    private var viewModel: SettingsViewModel?
+    var settingsSwitchTapped = PublishSubject<(CellActions, Any?)>()
     
     lazy var titleLabel: UILabel = {
         let label = UILabel()
@@ -53,20 +54,19 @@ final class SettingsSwitchCell: UITableViewCell {
         }
     }
     
-    func configure(title: String, isOn: Bool, action: CellActions, viewModel: SettingsViewModel) {
+    func configure(title: String, isOn: Bool, action: CellActions) {
         titleLabel.text = title
         switchButton.isOn = isOn
         switchButton.tag = action.toRow
-        self.viewModel = viewModel
     }
     
     @objc private func switchButtonTapped() {
-        let action = CellActions(rawValue: switchButton.tag)
+        guard let action = CellActions(rawValue: switchButton.tag) else { return }
+        let switchStatus = switchButton.isOn
         switch action {
         case .autoplay:
-            debugPrint("\(switchButton.isOn) / autoPlay 관련 액션을 실행합니다.")
-            guard let viewModel = viewModel else { return }
-            viewModel.changeAutoPlayMode(to: switchButton.isOn)
+            settingsSwitchTapped
+                .onNext((action, switchStatus))
         default:
             break
         }

--- a/Segno/Segno/Presentation/ViewController/SettingsViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/SettingsViewController.swift
@@ -46,7 +46,6 @@ final class SettingsViewController: UIViewController {
         setupView()
         setupLayout()
         bindTableView()
-        bind()
     }
     
     private func setupView() {
@@ -69,27 +68,31 @@ final class SettingsViewController: UIViewController {
                     guard let cell = tableView.dequeueReusableCell(withIdentifier: "NicknameCell") as? NicknameCell,
                           let self = self else { return UITableViewCell() }
                     
-                    cell.nicknameChangeButtonTapped
-                        .flatMap { nickname in
-                            self.viewModel.changeNickname(to: nickname)
+                    cell.okButton.rx.tap
+                        .flatMap { a in
+                            guard let newNickname = cell.nicknameTextField.text else {
+                                return Observable<Bool>.empty()
+                            }
+                            debugPrint("입력된 아이디 : ", newNickname)
+                            return self.viewModel.changeNickname(to: newNickname)
                         }
                         .subscribe(onNext: { result in
-                            // TODO: result 결과에 따른 Alert 작성
                             debugPrint("viewModel 메서드 실행 결과 : ", result)
                         })
                         .disposed(by: self.disposeBag)
+                    
                     return cell
                 case .settingsSwitch(let title, let isOn):
                     guard let cell = tableView.dequeueReusableCell(withIdentifier: "SettingsSwitchCell") as? SettingsSwitchCell,
                           let action = CellActions(rawValue: row),
                           let self = self else { return UITableViewCell() }
                     
-                    cell.settingsSwitchTapped
-                        .subscribe(onNext: { (cellActions, value) in
-                            switch cellActions {
+                    cell.switchButton.rx.controlEvent(.touchUpInside)
+                        .subscribe(onNext: {
+                            let isOn = cell.switchButton.isOn
+                            switch action {
                             case .autoplay:
-                                guard let value = value as? Bool else { return }
-                                return self.viewModel.changeAutoPlayMode(to: value)
+                                self.viewModel.changeAutoPlayMode(to: isOn)
                             default:
                                 break
                             }
@@ -99,18 +102,9 @@ final class SettingsViewController: UIViewController {
                     cell.configure(title: title, isOn: isOn, action: action)
                     return cell
                 case .settingsActionSheet(let title):
-                    guard let cell = tableView.dequeueReusableCell(withIdentifier: "SettingsActionSheetCell") as? SettingsActionSheetCell,
-                          let self = self else { return UITableViewCell() }
-                    
-                    cell.settingsActionSheetTapped
-                        .subscribe(onNext: { (actionSheetMode, value) in
-                            switch actionSheetMode {
-                            case .darkmode:
-                                guard let status = value as? Int else { return }
-                                self.viewModel.changeDarkMode(to: status)
-                            }
-                        })
-                        .disposed(by: self.disposeBag)
+                    guard let cell = tableView.dequeueReusableCell(withIdentifier: "SettingsActionSheetCell") as? SettingsActionSheetCell else {
+                        return UITableViewCell()
+                    }
                     
                     cell.configure(title: title)
                     return cell
@@ -124,19 +118,22 @@ final class SettingsViewController: UIViewController {
                 guard let action = CellActions(rawValue: indexPath.row) else { return }
                 switch action {
                 case .darkmode: // 다크 모드 설정
-                    guard let cell = self?.tableView.cellForRow(at: indexPath) as? SettingsActionSheetCell else { return }
-                    cell.tapped(mode: .darkmode) { alertController in
-                        self?.present(alertController, animated: true)
-                    }
+                    let actionSheet = UIAlertController(title: "다크 모드 설정", message: nil, preferredStyle: .actionSheet)
+                    actionSheet.addAction(UIAlertAction(title: "시스템 설정", style: .default, handler: { _ in
+                        self?.viewModel.changeDarkMode(to: 0)
+                    }))
+                    actionSheet.addAction(UIAlertAction(title: "항상 밝게", style: .default, handler: { _ in
+                        self?.viewModel.changeDarkMode(to: 1)
+                    }))
+                    actionSheet.addAction(UIAlertAction(title: "항상 어둡게", style: .default, handler: { _ in
+                        self?.viewModel.changeDarkMode(to: 2)
+                    }))
+                    self?.present(actionSheet, animated: true)
                 default:
                     break
                 }
             })
             .disposed(by: disposeBag)
-    }
-    
-    private func bind() {
-        
     }
 }
 

--- a/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
@@ -19,4 +19,39 @@ final class SettingsViewModel {
     init() {
         
     }
+    
+    // TODO: 닉네임 변경 로직
+    func changeNickname(to nickname: String) -> Observable<Bool> {
+//        return useCase.requestChangeNickname(to: nickname)
+        
+        // 임시 처리입니다.
+        return Observable.create { emitter in
+            emitter.onNext(true)
+            return Disposables.create()
+        }
+    }
+    
+    // TODO: 음악 자동 재생 여부 불러오기 / 클릭 시 반영하기
+    func getAutoPlayMode() -> Bool {
+        // return useCase.getAutoPlayMode()
+        
+        // 임시 값입니다.
+        return true
+    }
+    
+    func changeAutoPlayMode(to mode: Bool) {
+//        useCase.changeAutoPlayMode(to: mode)
+    }
+    
+    // TODO: 다크모드 설정 불러오기 / 액션 시트 선택 시 반영하기
+    func getDarkMode() -> Int {
+        // return useCase.getDarkMode()
+        
+        // 임시 값입니다.
+        return 0
+    }
+    
+    func changeAutoPlayMode() {
+        // TODO: 액션 시트를 띄워야 합니다.
+    }
 }

--- a/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
@@ -35,23 +35,24 @@ final class SettingsViewModel {
     func getAutoPlayMode() -> Bool {
         // return useCase.getAutoPlayMode()
         
-        // 임시 값입니다.
         return true
     }
     
     func changeAutoPlayMode(to mode: Bool) {
 //        useCase.changeAutoPlayMode(to: mode)
+        
+        debugPrint("changeAutoPlayMode에서 \(mode)로 변경합니다")
     }
     
     // TODO: 다크모드 설정 불러오기 / 액션 시트 선택 시 반영하기
     func getDarkMode() -> Int {
         // return useCase.getDarkMode()
         
-        // 임시 값입니다.
         return 0
     }
     
-    func changeAutoPlayMode() {
+    func changeDarkMode(to mode: Int) {
         // TODO: 액션 시트를 띄워야 합니다.
+        debugPrint("changeDarkMode에서 \(mode)로 변경합니다")
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  SettingsViewModel.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/11/29.
+//
+
+import Foundation
+
+import RxSwift
+
+final class SettingsViewModel {
+    let dataSource = Observable<[SettingsCellModel]>.just([
+        .nickname,
+        .settingsSwitch(title: "음악 자동 재생", isOn: true), // TODO: isOn은 로컬 디비로부터 불러와야 합니다.
+        .settingsActionSheet(title: "다크 모드")
+    ])
+    
+    init() {
+        
+    }
+}


### PR DESCRIPTION
11/29 #96 #112 

## 작업한 내용
### 열거형을 사용하여 셀의 액션을 식별할 수 있도록 변경하였습니다.
- 기존에 tableView의 row 값이라는 하드 코딩 데이터를 이용하여 액션을 식별하는 것이 바람직하지 않다고 생각하여 위 방식으로 변경하였습니다.
### dataSource 위치를 viewModel로 이동하였습니다.
### 뷰모델을 작성하였습니다.
- 유즈케이스 작성 및 연결은 내일 진행하도록 하겠습니다.
### Cell로 ViewModel을 주입하지 않고, PublishSubject를 이용하도록 변경하였습니다.
- 금일 피드백을 반영하여, 위 방향으로 변경했습니다. 자세한 사항은 밑에 기술했습니다.

## 고민한 점 및 어려웠던 점
### 셀 내부의 액션을 어떻게 뷰모델의 메서드와 연관지을지 고민했습니다.
- 셀도 View이니 ViewModel을 주입받아도 되지 않을까 싶었는데, 셀에 뷰모델을 주입하는 건 과하다는 피드백을 반영하여 셀에 뷰모델을 직접 주입하지 않고, PublishSubject를 통해 ViewController에서 이벤트를 관찰하도록 하고, 필요에 따라 completionHandler도 이용하는 방식으로 변경했습니다.
### 액션 시트도 코디네이터를 이용해야 할까? 고민됩니다.
- 액션 시트, Alert도 코디네이터를 이용해야 하는지 저희가 이야기 한 적 있었는지 제가 잘 기억이 나지 않아서,,, 코멘트 달아주시면 감사하겠습니다. 일단 코디네이터를 이용하지 않는 방향으로 작성해봤습니다. 어느 방향이든 추후 extension으로 분리하긴 해야합니다.
