### PR TITLE
Feature/diary detail logic

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -47,6 +47,10 @@
 		6692A9EF292F605E00DDA835 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6692A9EE292F605E00DDA835 /* SettingsViewController.swift */; };
 		66F0D7EE2925FF8B0074872E /* DiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F0D7ED2925FF8B0074872E /* DiaryCell.swift */; };
 		66F0D7F729260BA20074872E /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 66F0D7F629260BA20074872E /* GoogleSignIn */; };
+		791529D82932F364005A8DDB /* DiaryEditUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791529D72932F364005A8DDB /* DiaryEditUseCase.swift */; };
+		791529DC29332CF2005A8DDB /* ImageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791529DB29332CF2005A8DDB /* ImageDTO.swift */; };
+		791529DE29333D40005A8DDB /* ImageEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791529DD29333D40005A8DDB /* ImageEndpoint.swift */; };
+		791529E0293344E9005A8DDB /* DiaryPostEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791529DF293344E8005A8DDB /* DiaryPostEndpoint.swift */; };
 		791837FA292225C600BC6992 /* Cafe24Shiningstar.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 791837F7292225BF00BC6992 /* Cafe24Shiningstar.ttf */; };
 		791837FB292225C800BC6992 /* Cafe24Ssurround.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 791837F9292225BF00BC6992 /* Cafe24Ssurround.ttf */; };
 		791837FC292225CB00BC6992 /* Cafe24SsurroundAir.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 791837F8292225BF00BC6992 /* Cafe24SsurroundAir.ttf */; };
@@ -111,6 +115,10 @@
 		6692A9EE292F605E00DDA835 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		66F0D7ED2925FF8B0074872E /* DiaryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		66F0D7EF292605AE0074872E /* Segno.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Segno.entitlements; sourceTree = "<group>"; };
+		791529D72932F364005A8DDB /* DiaryEditUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditUseCase.swift; sourceTree = "<group>"; };
+		791529DB29332CF2005A8DDB /* ImageDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDTO.swift; sourceTree = "<group>"; };
+		791529DD29333D40005A8DDB /* ImageEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageEndpoint.swift; sourceTree = "<group>"; };
+		791529DF293344E8005A8DDB /* DiaryPostEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryPostEndpoint.swift; sourceTree = "<group>"; };
 		791837F7292225BF00BC6992 /* Cafe24Shiningstar.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Cafe24Shiningstar.ttf; sourceTree = "<group>"; };
 		791837F8292225BF00BC6992 /* Cafe24SsurroundAir.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Cafe24SsurroundAir.ttf; sourceTree = "<group>"; };
 		791837F9292225BF00BC6992 /* Cafe24Ssurround.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Cafe24Ssurround.ttf; sourceTree = "<group>"; };
@@ -266,6 +274,7 @@
 				9841D6162925FACC00318EA9 /* LoginUseCase.swift */,
 				7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */,
 				988414DA2923606B007C9132 /* DiaryListUseCase.swift */,
+				791529D72932F364005A8DDB /* DiaryEditUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -356,6 +365,7 @@
 				4F4E0D73292521D0005ABA8F /* UserInfoDTO.swift */,
 				7940FB2E292E063100276EFC /* DiaryDetailDTO.swift */,
 				4F4E0D7A29252526005ABA8F /* TokenDTO.swift */,
+				791529DB29332CF2005A8DDB /* ImageDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -365,7 +375,9 @@
 			children = (
 				4FA3242A2923646F00DB04D5 /* DiaryListItemEndpoint.swift */,
 				7940FB30292E065100276EFC /* DiaryDetailEndpoint.swift */,
+				791529DF293344E8005A8DDB /* DiaryPostEndpoint.swift */,
 				4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */,
+				791529DD29333D40005A8DDB /* ImageEndpoint.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -485,6 +497,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */,
+				791529DE29333D40005A8DDB /* ImageEndpoint.swift in Sources */,
 				4F4E0D3E2924B925005ABA8F /* LoginRepository.swift in Sources */,
 				4F9A00212922338E007D9057 /* AppDelegate.swift in Sources */,
 				66F0D7EE2925FF8B0074872E /* DiaryCell.swift in Sources */,
@@ -514,6 +527,7 @@
 				666E6F8A291CF82700CECD4B /* TabBarPageCase.swift in Sources */,
 				79183800292225DC00BC6992 /* UIFont+.swift in Sources */,
 				666E6F83291CF4A600CECD4B /* TabBarCoordinator.swift in Sources */,
+				791529E0293344E9005A8DDB /* DiaryPostEndpoint.swift in Sources */,
 				4F9A001D29222B1B007D9057 /* Endpoint.swift in Sources */,
 				4F9A001F29222C97007D9057 /* NetworkError.swift in Sources */,
 				98FDF8A1292F56580083FA05 /* Location.swift in Sources */,
@@ -526,11 +540,13 @@
 				4FA3242B2923646F00DB04D5 /* DiaryListItemEndpoint.swift in Sources */,
 				791837FF292225DC00BC6992 /* UIColor+.swift in Sources */,
 				666E6F7F291CF46800CECD4B /* AppCoordinator.swift in Sources */,
+				791529DC29332CF2005A8DDB /* ImageDTO.swift in Sources */,
 				9841D61B2926131200318EA9 /* LoginViewModel.swift in Sources */,
 				988414D72923304F007C9132 /* KeychainError.swift in Sources */,
 				98B5263E292CA46C00446413 /* TagView.swift in Sources */,
 				7940FB2F292E063100276EFC /* DiaryDetailDTO.swift in Sources */,
 				4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */,
+				791529D82932F364005A8DDB /* DiaryEditUseCase.swift in Sources */,
 				4FA324262923600C00DB04D5 /* DiaryListDTO.swift in Sources */,
 				666E6F87291CF4B400CECD4B /* DiaryCoordinator.swift in Sources */,
 				4F31777F291BE4710019BDFC /* SceneDelegate.swift in Sources */,

--- a/Segno/Segno/Data/Network/Endpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoint.swift
@@ -20,6 +20,7 @@ enum HTTPMethod: String {
 enum HTTPRequestParameter {
     case queries(Queries)
     case body(Body)
+    case data(Data)
 }
 
 // MARK: Endpoint 본체
@@ -35,7 +36,12 @@ protocol Endpoint {
 
 extension Endpoint {
     var headers: Headers {
-        return ["Content-Type": "application/json"]
+        switch self.parameters {
+        case .data(_):
+            return ["Content-Type": "multipart/form-data; boundary=SEGNO"]
+        default:
+            return ["Content-Type": "application/json"]
+        }
     }
     
     func toURLRequest() throws -> URLRequest {

--- a/Segno/Segno/Data/Network/Endpoints/DiaryPostEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/DiaryPostEndpoint.swift
@@ -1,0 +1,31 @@
+//
+//  DiaryPostEndpoint.swift
+//  Segno
+//
+//  Created by TaehoYoo on 2022/11/27.
+//
+
+import Foundation
+
+enum DiaryPostEndpoint: Endpoint {
+    case item(DiaryDetail)
+    
+    var baseURL: URL? {
+        return URL(string: BaseURL.urlString)
+    }
+    
+    var httpMethod: HTTPMethod {
+        return .GET
+    }
+    
+    var path: String {
+        return "diary"
+    }
+    
+    var parameters: HTTPRequestParameter? {
+        switch self {
+        case .item(let diary):
+            return HTTPRequestParameter.body(diary)
+        }
+    }
+}

--- a/Segno/Segno/Data/Network/Endpoints/ImageEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/ImageEndpoint.swift
@@ -1,0 +1,31 @@
+//
+//  ImageEndpoint.swift
+//  Segno
+//
+//  Created by TaehoYoo on 2022/11/27.
+//
+
+import Foundation
+
+enum ImageEndpoint: Endpoint {
+    case item(Data)
+    
+    var baseURL: URL? {
+        return URL(string: BaseURL.urlString)
+    }
+    
+    var httpMethod: HTTPMethod {
+        return .POST
+    }
+    
+    var path: String {
+        return "image"
+    }
+    
+    var parameters: HTTPRequestParameter? {
+        switch self {
+        case .item(let image):
+            return HTTPRequestParameter.data(image)
+        }
+    }
+}

--- a/Segno/Segno/Data/Repository/DTO/ImageDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/ImageDTO.swift
@@ -1,0 +1,10 @@
+//
+//  ImageDTO.swift
+//  Segno
+//
+//  Created by TaehoYoo on 2022/11/27.
+//
+
+struct ImageDTO: Decodable {
+    let filename: String?
+}

--- a/Segno/Segno/Data/Repository/DiaryRepository.swift
+++ b/Segno/Segno/Data/Repository/DiaryRepository.swift
@@ -12,6 +12,7 @@ import RxSwift
 protocol DiaryRepository {
     func getDiaryListItem() -> Single<DiaryListDTO>
     func getDiary(id: String) -> Single<DiaryDetailDTO>
+    func postDiary(_ diary: DiaryDetail, image: Data) -> Single<DiaryDetailDTO>
 }
 
 final class DiaryRepositoryImpl: DiaryRepository {
@@ -46,5 +47,36 @@ final class DiaryRepositoryImpl: DiaryRepository {
 //
 //            return Disposables.create()
 //        }
+    }
+    
+    func postDiary(_ diary: DiaryDetail, image: Data) -> Single<DiaryDetailDTO> {
+        // Dummy endpoint
+        
+        let imageEndpoint = ImageEndpoint.item(image)
+
+        let single = NetworkManager.shared.call(imageEndpoint)
+            .compactMap {
+                // image 전송 후 이름 받아오기
+                let imageDTO = try JSONDecoder().decode(ImageDTO.self, from: $0)
+                return imageDTO.filename
+            }.map { imagePath in
+                // diary에 imagePath넣어 전달
+                return DiaryDetail(diary, imagePath: imagePath)
+            }.flatMap { diaryDetail in
+                // diary를 다시 서버에 전달
+                // TODO: - token 넣어야됩니당
+                let testDiaryDetail = DiaryDetail(diaryDetail, token: "0KjV78s0YPKbrlVP3QeAwUJcjohs2h2ysdWDLWg")
+                                
+                let diaryDetailEndpoint = DiaryPostEndpoint.item(testDiaryDetail)
+                
+                return NetworkManager.shared.call(diaryDetailEndpoint)
+                    .map { try JSONDecoder().decode(DiaryDetailDTO.self, from: $0) }
+                    .asObservable()
+                    .asMaybe()
+            }
+            .asObservable()
+            .asSingle()
+        
+        return single
     }
 }

--- a/Segno/Segno/Domain/UseCase/DiaryEditUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/DiaryEditUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  DiaryEditUseCase.swift
+//  Segno
+//
+//  Created by TaehoYoo on 2022/11/27.
+//
+import Foundation
+
+import RxSwift
+
+protocol DiaryEditUseCase {
+    func postDiary(_ diary: DiaryDetail, image: Data) -> Single<DiaryDetail>
+}
+
+final class DiaryEditUseCaseImpl: DiaryEditUseCase {
+    let repository: DiaryRepository
+    private let disposeBag = DisposeBag()
+    
+    init(repository: DiaryRepository = DiaryRepositoryImpl()) {
+        self.repository = repository
+    }
+    
+    func postDiary(_ diary: DiaryDetail, image: Data) -> Single<DiaryDetail> {
+        repository.postDiary(diary, image: image).map { dto in
+            DiaryDetail(
+                identifier: dto.id,
+                title: dto.title,
+                tags: dto.tags,
+                imagePath: dto.imagePath,
+                bodyText: dto.bodyText,
+                // TODO: MusicInfo, location 업데이트
+                musicInfo: nil,
+                location: nil
+            )
+        }
+    }
+}

--- a/Segno/Segno/Entity/DiaryDetail.swift
+++ b/Segno/Segno/Entity/DiaryDetail.swift
@@ -5,15 +5,52 @@
 //  Created by Gordon Choi on 2022/11/10.
 //
 
-// TODO: 코어 로케이션에서 좌표만 뽑아와서 저장하기
-import CoreLocation
-
-struct DiaryDetail {
+struct DiaryDetail: Encodable {
     let identifier: String
     let title: String
     let tags: [String]
     let imagePath: String
     let bodyText: String?
     let musicInfo: MusicInfo?
-    let location: CLLocation?
+    let location: Location?
+    
+    var token: String?
+    
+    init(identifier: String, title: String, tags: [String], imagePath: String, bodyText: String?, musicInfo: MusicInfo?, location: Location?, token: String? = nil) {
+        self.identifier = identifier
+        self.title = title
+        self.tags = tags
+        self.imagePath = imagePath
+        self.bodyText = bodyText
+        self.musicInfo = musicInfo
+        self.location = location
+        self.token = token
+    }
+    
+    init(_ diary: DiaryDetail, imagePath: String) {
+        self.init(
+            identifier: diary.identifier,
+            title: diary.title,
+            tags: diary.tags,
+            imagePath: imagePath,
+            bodyText: diary.bodyText,
+            musicInfo: diary.musicInfo,
+            location: diary.location,
+            token: diary.token
+        )
+    }
+    
+    // DUMMY
+    init(_ diary: DiaryDetail, token: String) {
+        self.init(
+            identifier: diary.identifier,
+            title: diary.title,
+            tags: diary.tags,
+            imagePath: diary.imagePath,
+            bodyText: diary.bodyText,
+            musicInfo: diary.musicInfo,
+            location: diary.location,
+            token: token
+        )
+    }
 }

--- a/Segno/Segno/Entity/Location.swift
+++ b/Segno/Segno/Entity/Location.swift
@@ -6,8 +6,14 @@
 //
 
 import Foundation
+import CoreLocation
 
-struct Location {
+struct Location: Encodable {
     let latitude: Double
     let longitude: Double
+    
+    // TODO: 이 방법이 옳은지 논의를 해봐야합니다.
+    func createCLLocation() -> CLLocation {
+        CLLocation(latitude: self.latitude, longitude: self.longitude)
+    }
 }

--- a/Segno/Segno/Entity/MusicInfo.swift
+++ b/Segno/Segno/Entity/MusicInfo.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ShazamKit
 
-struct MusicInfo {
+struct MusicInfo: Encodable {
     let title: String
     let artist: String
     let album: String

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -218,6 +218,7 @@ final class DiaryDetailViewController: UIViewController {
         
         viewModel.locationObservable
             .compactMap { $0 }
+            .map { $0.createCLLocation() }
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] location in
                 self?.locationContentView.setLocation(location: location)


### PR DESCRIPTION
11/30 #117 #116 #115 

## 수행한 일
### Diary Detail C_UD 작성
- DTO도 추가하였습니다.
### Diary C_UD, image 를 위한 Endpoint 작성
- Method에 Patch, Delete 추가하였습니다.
- Data 전송을 위해 NetworkManager를 수정하였습니다.
    - FormData 전송을 위한 메소드를 추가하였습니다.
- Delete의 경우 결괏값이 필요 없기에, Single<Void>로 작성하였습니다.

## 고민한 점 및 어려웠던 점
### 네트워크 관련
- network 통신에서 정보를 보내고, 값을 받지 않은채로 넘어가버립니다.. async/await를 적용해야할지 고민입니다.
- DiaryDetail을 살짝 수정해놓았습니다. 후에 서버 구조를 바꾸고 같이 바꿀 예정입니다.(Identifier, token 부분)
### 코드 품질 관련
- 코드의 재사용이 빈번하고, 클로저의 생성과 동시에 사용이 많아 depth가 좀 깊습니다. 후에 리팩토링 하겠습니다.
### 작업의 양
- 하나 할때마다 이것도 해야하지 않나? 이것도 바꿔야되네?를 계속하다보니 pr의 크기가 좀 많이 커졌습니다. 다음부턴 신경쓰겠습니다..