### PR TITLE
SettingsRepository 및 닉네임 변경 구현

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
 		982A3699292C905300FDC6CF /* DiaryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */; };
 		982B3B7F292E68FB0077A44B /* DiaryDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982B3B7E292E68FB0077A44B /* DiaryDetailViewModel.swift */; };
+		9838443E29387C0A00BCCEE2 /* ChangeNicknameEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9838443D29387C0A00BCCEE2 /* ChangeNicknameEndpoint.swift */; };
 		983AE9D22934F041006547BD /* NicknameCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AE9D12934F041006547BD /* NicknameCell.swift */; };
 		983AE9D4293513AD006547BD /* SettingsCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AE9D3293513AD006547BD /* SettingsCellModel.swift */; };
 		983AE9D6293514E8006547BD /* SettingsActionSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AE9D5293514E8006547BD /* SettingsActionSheetCell.swift */; };
@@ -155,6 +156,7 @@
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewController.swift; sourceTree = "<group>"; };
 		982B3B7E292E68FB0077A44B /* DiaryDetailViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewModel.swift; sourceTree = "<group>"; };
+		9838443D29387C0A00BCCEE2 /* ChangeNicknameEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameEndpoint.swift; sourceTree = "<group>"; };
 		983AE9D12934F041006547BD /* NicknameCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameCell.swift; sourceTree = "<group>"; };
 		983AE9D3293513AD006547BD /* SettingsCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCellModel.swift; sourceTree = "<group>"; };
 		983AE9D5293514E8006547BD /* SettingsActionSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsActionSheetCell.swift; sourceTree = "<group>"; };
@@ -307,10 +309,10 @@
 			isa = PBXGroup;
 			children = (
 				9841D6162925FACC00318EA9 /* LoginUseCase.swift */,
-				7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */,
 				988414DA2923606B007C9132 /* DiaryListUseCase.swift */,
-				66A8CF682937945300C17F84 /* UserDetailUseCase.swift */,
+				7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */,
 				791529D72932F364005A8DDB /* DiaryEditUseCase.swift */,
+				66A8CF682937945300C17F84 /* UserDetailUseCase.swift */,
 				9894EAF429373385005F2B15 /* SettingsUseCase.swift */,
 				9825F41A29377875005F2163 /* ChangeUserNameUseCase.swift */,
 			);
@@ -426,6 +428,7 @@
 				4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */,
 				66A8CF6C29379A9900C17F84 /* UserDetailEndpoint.swift */,
 				791529DD29333D40005A8DDB /* ImageEndpoint.swift */,
+				9838443D29387C0A00BCCEE2 /* ChangeNicknameEndpoint.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -593,6 +596,7 @@
 				982A3699292C905300FDC6CF /* DiaryDetailViewController.swift in Sources */,
 				9825F41B29377875005F2163 /* ChangeUserNameUseCase.swift in Sources */,
 				666E6F8C291CFAC200CECD4B /* DiaryCollectionViewController.swift in Sources */,
+				9838443E29387C0A00BCCEE2 /* ChangeNicknameEndpoint.swift in Sources */,
 				666E6F8A291CF82700CECD4B /* TabBarPageCase.swift in Sources */,
 				66A8CF652937934A00C17F84 /* MyPageRepository.swift in Sources */,
 				79183800292225DC00BC6992 /* UIFont+.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		7940FB2F292E063100276EFC /* DiaryDetailDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB2E292E063100276EFC /* DiaryDetailDTO.swift */; };
 		7940FB31292E065100276EFC /* DiaryDetailEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB30292E065100276EFC /* DiaryDetailEndpoint.swift */; };
 		7940FB33292E065F00276EFC /* DiaryDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */; };
-		9825F41B29377875005F2163 /* ChangeUserNameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41A29377875005F2163 /* ChangeUserNameUseCase.swift */; };
+		9825F41B29377875005F2163 /* ChangeNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */; };
 		9825F41D29377ACF005F2163 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41C29377ACF005F2163 /* SettingsRepository.swift */; };
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
 		982A3699292C905300FDC6CF /* DiaryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */; };
@@ -151,7 +151,7 @@
 		7940FB2E292E063100276EFC /* DiaryDetailDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailDTO.swift; sourceTree = "<group>"; };
 		7940FB30292E065100276EFC /* DiaryDetailEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailEndpoint.swift; sourceTree = "<group>"; };
 		7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailUseCase.swift; sourceTree = "<group>"; };
-		9825F41A29377875005F2163 /* ChangeUserNameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeUserNameUseCase.swift; sourceTree = "<group>"; };
+		9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameUseCase.swift; sourceTree = "<group>"; };
 		9825F41C29377ACF005F2163 /* SettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepository.swift; sourceTree = "<group>"; };
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewController.swift; sourceTree = "<group>"; };
@@ -314,7 +314,7 @@
 				791529D72932F364005A8DDB /* DiaryEditUseCase.swift */,
 				66A8CF682937945300C17F84 /* UserDetailUseCase.swift */,
 				9894EAF429373385005F2B15 /* SettingsUseCase.swift */,
-				9825F41A29377875005F2163 /* ChangeUserNameUseCase.swift */,
+				9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -594,7 +594,7 @@
 				66A8CF672937937300C17F84 /* UserDetailItem.swift in Sources */,
 				666E6F7D291CF45600CECD4B /* Coordinator.swift in Sources */,
 				982A3699292C905300FDC6CF /* DiaryDetailViewController.swift in Sources */,
-				9825F41B29377875005F2163 /* ChangeUserNameUseCase.swift in Sources */,
+				9825F41B29377875005F2163 /* ChangeNicknameUseCase.swift in Sources */,
 				666E6F8C291CFAC200CECD4B /* DiaryCollectionViewController.swift in Sources */,
 				9838443E29387C0A00BCCEE2 /* ChangeNicknameEndpoint.swift in Sources */,
 				666E6F8A291CF82700CECD4B /* TabBarPageCase.swift in Sources */,

--- a/Segno/Segno/Data/Network/Endpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoint.swift
@@ -13,7 +13,7 @@ typealias Body = Encodable
 
 // MARK: HTTP 요청 메서드
 enum HTTPMethod: String {
-    case GET, POST, PUT, DELETE
+    case GET, POST, PUT, DELETE, PATCH
 }
 
 // MARK: 요청 파라미터

--- a/Segno/Segno/Data/Network/Endpoints/ChangeNicknameEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/ChangeNicknameEndpoint.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum ChangeNicknameEndpoint: Endpoint {
-    case item(String, String)
+    case item(token: String, nickname: String)
     
     var baseURL: URL? {
         return URL(string: BaseURL.urlString)

--- a/Segno/Segno/Data/Network/Endpoints/ChangeNicknameEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/ChangeNicknameEndpoint.swift
@@ -1,0 +1,31 @@
+//
+//  SettingsEndpoint.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/12/01.
+//
+
+import Foundation
+
+enum ChangeNicknameEndpoint: Endpoint {
+    case item(String, String)
+    
+    var baseURL: URL? {
+        return URL(string: BaseURL.urlString)
+    }
+    
+    var httpMethod: HTTPMethod {
+        return .PATCH
+    }
+    
+    var path: String {
+        return "user"
+    }
+    
+    var parameters: HTTPRequestParameter? {
+        switch self {
+        case .item(let token, let nickName):
+            return HTTPRequestParameter.body(["token": token, "nickName": nickName])
+        }
+    }
+}

--- a/Segno/Segno/Data/Repository/SettingsRepository.swift
+++ b/Segno/Segno/Data/Repository/SettingsRepository.swift
@@ -8,9 +8,17 @@
 import RxSwift
 
 protocol SettingsRepository {
-
+    func changeNickname(to nickname: String) -> Single<Bool>
 }
 
 final class SettingsRepositoryImpl: SettingsRepository {
-    
+    func changeNickname(to nickname: String) -> Single<Bool> {
+        // TODO: Keychain으로부터 토큰 가져오기
+        let token = "/43JoWf24Y7SS8yJj3oIPqIFGZRD3P7u9kUZVwkMwug="
+        let endpoint = ChangeNicknameEndpoint.item(token, nickname)
+        return NetworkManager.shared.call(endpoint)
+            .map { _ in
+                return true
+            }
+    }
 }

--- a/Segno/Segno/Data/Repository/SettingsRepository.swift
+++ b/Segno/Segno/Data/Repository/SettingsRepository.swift
@@ -15,7 +15,7 @@ final class SettingsRepositoryImpl: SettingsRepository {
     func changeNickname(to nickname: String) -> Single<Bool> {
         // TODO: Keychain으로부터 토큰 가져오기
         let token = "/43JoWf24Y7SS8yJj3oIPqIFGZRD3P7u9kUZVwkMwug="
-        let endpoint = ChangeNicknameEndpoint.item(token, nickname)
+        let endpoint = ChangeNicknameEndpoint.item(token: token, nickname: nickname)
         return NetworkManager.shared.call(endpoint)
             .map { _ in
                 return true

--- a/Segno/Segno/Domain/UseCase/ChangeNicknameUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/ChangeNicknameUseCase.swift
@@ -1,5 +1,5 @@
 //
-//  ChangeUserNameUseCase.swift
+//  ChangeNicknameUseCase.swift
 //  Segno
 //
 //  Created by YOONJONG on 2022/11/30.
@@ -7,11 +7,11 @@
 
 import RxSwift
 
-protocol ChangeUserNameUseCase {
+protocol ChangeNicknameUseCase {
     func requestChangeNickname(to nickname: String) -> Single<Bool>
 }
 
-final class ChangeUserNameUseCaseImpl: ChangeUserNameUseCase {
+final class ChangeNicknameUseCaseImpl: ChangeNicknameUseCase {
     let repository: SettingsRepository
     private let disposeBag = DisposeBag()
     

--- a/Segno/Segno/Domain/UseCase/ChangeUserNameUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/ChangeUserNameUseCase.swift
@@ -8,7 +8,7 @@
 import RxSwift
 
 protocol ChangeUserNameUseCase {
-    func requestChangeNickname(to nickname: String) -> Bool
+    func requestChangeNickname(to nickname: String) -> Single<Bool>
 }
 
 final class ChangeUserNameUseCaseImpl: ChangeUserNameUseCase {
@@ -19,9 +19,7 @@ final class ChangeUserNameUseCaseImpl: ChangeUserNameUseCase {
         self.repository = repository
     }
     
-    func requestChangeNickname(to nickname: String) -> Bool {
-        // 임시 처리입니다.
-        debugPrint("SettingsUseCase - requestChangeNickname : \(nickname)으로 변경")
-        return true
+    func requestChangeNickname(to nickname: String) -> Single<Bool> {
+        return repository.changeNickname(to: nickname)
     }
 }

--- a/Segno/Segno/Presentation/ViewController/SettingsViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/SettingsViewController.swift
@@ -70,17 +70,19 @@ final class SettingsViewController: UIViewController {
                           let self = self else { return UITableViewCell() }
                     
                     cell.okButton.rx.tap
-                        .flatMap { a in
+                        .flatMap { _ in
                             guard let newNickname = cell.nicknameTextField.text else {
                                 return Observable<Bool>.empty()
                             }
+                            
                             return self.viewModel.changeNickname(to: newNickname)
+                                .asObservable()
                         }
                         .subscribe(onNext: { result in
-                            debugPrint("여기에서 \(result)에 대한 피드백 Alert 띄웁니다.")
+                            debugPrint("닉네임 변경 결과 : \(result)")
+                            // TODO: 성공/실패 알럿띄우기
                         })
                         .disposed(by: self.disposeBag)
-                    
                     return cell
                 case .settingsSwitch(let title, let isOn):
                     guard let cell = tableView.dequeueReusableCell(withIdentifier: "SettingsSwitchCell") as? SettingsSwitchCell,

--- a/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
@@ -17,17 +17,17 @@ final class SettingsViewModel {
     ])
     
     private let settingsUseCase: SettingsUseCase
-    private let changeUserNameUseCase: ChangeUserNameUseCase
+    private let changeNicknameUseCase: ChangeNicknameUseCase
     
     init(settingsUseCase: SettingsUseCase = SettingsUseCaseImpl(),
-         changeUserNameUseCase: ChangeUserNameUseCase = ChangeUserNameUseCaseImpl()
+         changeNicknameUseCase: ChangeNicknameUseCase = ChangeNicknameUseCaseImpl()
     ) {
         self.settingsUseCase = settingsUseCase
-        self.changeUserNameUseCase = changeUserNameUseCase
+        self.changeNicknameUseCase = changeNicknameUseCase
     }
     
     func changeNickname(to nickname: String) -> Single<Bool> {
-        return self.changeUserNameUseCase.requestChangeNickname(to: nickname)
+        return self.changeNicknameUseCase.requestChangeNickname(to: nickname)
     }
     
     func getAutoPlayMode() -> Bool {

--- a/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
@@ -26,12 +26,8 @@ final class SettingsViewModel {
         self.changeUserNameUseCase = changeUserNameUseCase
     }
     
-    func changeNickname(to nickname: String) -> Observable<Bool> {
-        return Observable.create { emitter in
-            let result = self.changeUserNameUseCase.requestChangeNickname(to: nickname)
-            emitter.onNext(result)
-            return Disposables.create()
-        }
+    func changeNickname(to nickname: String) -> Single<Bool> {
+        return self.changeUserNameUseCase.requestChangeNickname(to: nickname)
     }
     
     func getAutoPlayMode() -> Bool {


### PR DESCRIPTION
12/1 #127 #128 #145 #146 

## 작업한 내용
### 닉네임 변경을 위한 흐름을 완성했습니다.
- SettingsVC, SettingsViewModel, ChangeNicknameUseCase, SettingsRepository에 이르는 전체적인 흐름을 구축했습니다.
-  서버 명세에 따라 ChangeNickNameEndpoint를 생성했습니다.
- HTTPMethod 열거형에 PATCH를 추가했습니다.

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/29617557/204994228-9bd40195-288c-4957-b81f-9c2ff151e5e2.png">
