### PR TITLE
Diary Delete Logic 추가

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		7940FB2F292E063100276EFC /* DiaryDetailDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB2E292E063100276EFC /* DiaryDetailDTO.swift */; };
 		7940FB31292E065100276EFC /* DiaryDetailEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB30292E065100276EFC /* DiaryDetailEndpoint.swift */; };
 		7940FB33292E065F00276EFC /* DiaryDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */; };
+		79767E64293E2A1200E489DD /* DiaryDeleteEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */; };
 		9825F41B29377875005F2163 /* ChangeNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */; };
 		9825F41D29377ACF005F2163 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41C29377ACF005F2163 /* SettingsRepository.swift */; };
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
@@ -151,6 +152,7 @@
 		7940FB2E292E063100276EFC /* DiaryDetailDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailDTO.swift; sourceTree = "<group>"; };
 		7940FB30292E065100276EFC /* DiaryDetailEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailEndpoint.swift; sourceTree = "<group>"; };
 		7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailUseCase.swift; sourceTree = "<group>"; };
+		79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDeleteEndpoint.swift; sourceTree = "<group>"; };
 		9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameUseCase.swift; sourceTree = "<group>"; };
 		9825F41C29377ACF005F2163 /* SettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepository.swift; sourceTree = "<group>"; };
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
@@ -425,6 +427,7 @@
 				4FA3242A2923646F00DB04D5 /* DiaryListItemEndpoint.swift */,
 				7940FB30292E065100276EFC /* DiaryDetailEndpoint.swift */,
 				791529DF293344E8005A8DDB /* DiaryPostEndpoint.swift */,
+				79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */,
 				4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */,
 				66A8CF6C29379A9900C17F84 /* UserDetailEndpoint.swift */,
 				791529DD29333D40005A8DDB /* ImageEndpoint.swift */,
@@ -562,6 +565,7 @@
 				983AE9D82935CEE2006547BD /* SettingsViewModel.swift in Sources */,
 				9825F41D29377ACF005F2163 /* SettingsRepository.swift in Sources */,
 				66F0D7EE2925FF8B0074872E /* DiaryCell.swift in Sources */,
+				79767E64293E2A1200E489DD /* DiaryDeleteEndpoint.swift in Sources */,
 				4F9A00202922337F007D9057 /* LoginViewController.swift in Sources */,
 				982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */,
 				66A8CF6B2937947A00C17F84 /* UserDetailDTO.swift in Sources */,

--- a/Segno/Segno/Data/Network/Endpoints/DiaryDeleteEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/DiaryDeleteEndpoint.swift
@@ -1,0 +1,31 @@
+//
+//  DiaryDeleteEndpoint.swift
+//  Segno
+//
+//  Created by TaehoYoo on 2022/12/05.
+//
+
+import Foundation
+
+enum DiaryDeleteEndpoint: Endpoint {
+    case item(token: String, diaryId: String)
+    
+    var baseURL: URL? {
+        return URL(string: BaseURL.urlString)
+    }
+    
+    var httpMethod: HTTPMethod {
+        return .DELETE
+    }
+    
+    var path: String {
+        return "diary"
+    }
+    
+    var parameters: HTTPRequestParameter? {
+        switch self {
+        case .item(let token, let diaryId):
+            return HTTPRequestParameter.body(["token": token, "diaryId": diaryId])
+        }
+    }
+}

--- a/Segno/Segno/Data/Network/Endpoints/DiaryPostEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/DiaryPostEndpoint.swift
@@ -15,7 +15,7 @@ enum DiaryPostEndpoint: Endpoint {
     }
     
     var httpMethod: HTTPMethod {
-        return .GET
+        return .POST
     }
     
     var path: String {

--- a/Segno/Segno/Data/Repository/DiaryRepository.swift
+++ b/Segno/Segno/Data/Repository/DiaryRepository.swift
@@ -13,6 +13,7 @@ protocol DiaryRepository {
     func getDiaryListItem() -> Single<DiaryListDTO>
     func getDiary(id: String) -> Single<DiaryDetailDTO>
     func postDiary(_ diary: DiaryDetail, image: Data) -> Single<DiaryDetailDTO>
+    func deleteDiary(id: String) -> Single<Bool>
 }
 
 final class DiaryRepositoryImpl: DiaryRepository {
@@ -76,6 +77,20 @@ final class DiaryRepositoryImpl: DiaryRepository {
             }
             .asObservable()
             .asSingle()
+        
+        return single
+    }
+    
+    func deleteDiary(id: String) -> RxSwift.Single<Bool> {
+        //TODO: - Token 받아오기
+        let token = "0KjV78s0YPKbrlVP3QeAwUJcjohs2h2ysdWDLWg"
+        
+        let diaryDeleteEndpoint = DiaryDeleteEndpoint.item(token: token, diaryId: id)
+        
+        let single = NetworkManager.shared.call(diaryDeleteEndpoint)
+            .map { _ in
+                return true
+            }
         
         return single
     }


### PR DESCRIPTION
12/05

## 작업한 내용
### DiaryDeleteRepository 작성
- id, token만 보내면 되기에 추가적인 entity는 작성하지 않았습니다.
### DiaryRepository에 delete method 추가
- 삭제를 할 경우 추가적인 팝업이 나오지 않고, 추가적인 작업이 필요하지 않으므로 항상 true를 반환하도록 하였습니다.

로직상으로는 문제가 없다고 생각됩니다. 서버 작성 완료 후 테스트하고 문제가 있을 경우 수정하겠습니다.

## 고민한 점 및 어려웠던 점
### bool 값을 항상 true를 반환하는 것이 옳은가 합니다.
- Void를 하는게 맞나 싶습니다.
