### PR TITLE
다크모드 기능 구현

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		7940FB31292E065100276EFC /* DiaryDetailEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB30292E065100276EFC /* DiaryDetailEndpoint.swift */; };
 		7940FB33292E065F00276EFC /* DiaryDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */; };
 		79767E64293E2A1200E489DD /* DiaryDeleteEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */; };
+		98003E0E293F20F6009FBC35 /* DarkModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98003E0D293F20F6009FBC35 /* DarkModeManager.swift */; };
 		9825F41B29377875005F2163 /* ChangeNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */; };
 		9825F41D29377ACF005F2163 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41C29377ACF005F2163 /* SettingsRepository.swift */; };
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
@@ -162,6 +163,7 @@
 		7940FB30292E065100276EFC /* DiaryDetailEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailEndpoint.swift; sourceTree = "<group>"; };
 		7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailUseCase.swift; sourceTree = "<group>"; };
 		79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDeleteEndpoint.swift; sourceTree = "<group>"; };
+		98003E0D293F20F6009FBC35 /* DarkModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeManager.swift; sourceTree = "<group>"; };
 		9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameUseCase.swift; sourceTree = "<group>"; };
 		9825F41C29377ACF005F2163 /* SettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepository.swift; sourceTree = "<group>"; };
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 		4F317791291BEB490019BDFC /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				98003E0C293F20E7009FBC35 /* Manager */,
 				4FCAC5C3292B792200BF9CDD /* Session */,
 				4F3177A0291BF1810019BDFC /* Repository */,
 				4F31779F291BF1780019BDFC /* Network */,
@@ -477,6 +480,14 @@
 			path = Font;
 			sourceTree = "<group>";
 		};
+		98003E0C293F20E7009FBC35 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				98003E0D293F20F6009FBC35 /* DarkModeManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
 		9894EAF629375272005F2B15 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
@@ -592,6 +603,7 @@
 				66A8CF6D29379A9900C17F84 /* UserDetailEndpoint.swift in Sources */,
 				4FEBFAAD291CF62E00E78139 /* DiaryDetail.swift in Sources */,
 				4FEBFAB1291CFB5500E78139 /* SHMediaItem+.swift in Sources */,
+				98003E0E293F20F6009FBC35 /* DarkModeManager.swift in Sources */,
 				66A8CF692937945300C17F84 /* UserDetailUseCase.swift in Sources */,
 				988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */,
 				66A8CF612935F44100C17F84 /* MyPageViewModel.swift in Sources */,

--- a/Segno/Segno/Application/SceneDelegate.swift
+++ b/Segno/Segno/Application/SceneDelegate.swift
@@ -19,6 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let navigationController = UINavigationController()
         coordinator = AppCoordinator(navigationController)
         coordinator?.start()
+        setDarkMode()
         
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
@@ -29,5 +30,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillResignActive(_ scene: UIScene) { }
     func sceneWillEnterForeground(_ scene: UIScene) { }
     func sceneDidEnterBackground(_ scene: UIScene) { }
+    
+    private func setDarkMode() {
+        let mode = DarkModeManager.shared.getDarkMode()
+        DarkModeManager.shared.changeDarkMode(to: mode)
+    }
 }
 

--- a/Segno/Segno/Data/Manager/DarkModeManager.swift
+++ b/Segno/Segno/Data/Manager/DarkModeManager.swift
@@ -1,0 +1,41 @@
+//
+//  DarkModeManager.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/12/06.
+//
+
+import UIKit
+
+import RxSwift
+
+class DarkModeManager {
+    static let shared = DarkModeManager()
+    
+    let repository: LocalUtilityRepository
+    
+    private init() {
+        self.repository = LocalUtilityRepositoryImpl()
+    }
+    
+    func getDarkMode() -> Int {
+        if let mode = repository.getUserDefaultsObject(forKey: .darkmode) as? Int {
+            debugPrint("SettingsUseCase - getDarkMode : 키가 있습니다 - \(mode)")
+            return mode
+        } else {
+            repository.setUserDefaults(DarkMode.system.rawValue, forKey: .darkmode)
+            debugPrint("SettingsUseCase - getDarkMode : 키가 없어 \(DarkMode.system.rawValue) 로 설정합니다.")
+            return DarkMode.system.rawValue
+        }
+    }
+    
+    func changeDarkMode(to mode: Int) {
+        repository.setUserDefaults(mode, forKey: .darkmode)
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first else { return }
+        
+        window.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mode) ?? .unspecified
+        debugPrint("SettingsUseCase - changeDarkMode : \(mode)로 설정")
+        
+    }
+}

--- a/Segno/Segno/Data/Repository/LocalUtilityRepository.swift
+++ b/Segno/Segno/Data/Repository/LocalUtilityRepository.swift
@@ -88,13 +88,11 @@ final class LocalUtilityRepositoryImpl: LocalUtilityRepository {
     }
     
     func setUserDefaults(_ value: Any, forKey defaultsKey: UserDefaultsKey) {
-        let defaults = UserDefaults.standard
-        defaults.set(value, forKey: defaultsKey.rawValue)
+        UserDefaults.standard.set(value, forKey: defaultsKey.rawValue)
     }
     
     func getUserDefaultsObject(forKey defaultsKey: UserDefaultsKey) -> Any? {
-        let defaults = UserDefaults.standard
-        if let object = defaults.object(forKey: defaultsKey.rawValue) {
+        if let object = UserDefaults.standard.object(forKey: defaultsKey.rawValue) {
             return object
         } else {
             return nil

--- a/Segno/Segno/Domain/UseCase/SettingsUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/SettingsUseCase.swift
@@ -11,7 +11,7 @@ protocol SettingsUseCase {
     func getAutoPlayMode() -> Bool
     func changeAutoPlayMode(to mode: Bool)
     func getDarkMode() -> Int
-    func changeDarkMode(to mode: Int) -> Single<Int>
+    func changeDarkMode(to mode: Int)
 }
 
 final class SettingsUseCaseImpl: SettingsUseCase {
@@ -39,22 +39,10 @@ final class SettingsUseCaseImpl: SettingsUseCase {
     }
     
     func getDarkMode() -> Int {
-        if let mode = repository.getUserDefaultsObject(forKey: .darkmode) as? Int {
-            debugPrint("SettingsUseCase - getDarkMode : 키가 있습니다 - \(mode)")
-            return mode
-        } else {
-            repository.setUserDefaults(DarkMode.system.rawValue, forKey: .darkmode)
-            debugPrint("SettingsUseCase - getDarkMode : 키가 없어 \(DarkMode.system.rawValue) 로 설정합니다.")
-            return DarkMode.system.rawValue
-        }
+        return DarkModeManager.shared.getDarkMode()
     }
     
-    func changeDarkMode(to mode: Int) -> Single<Int> {
-        repository.setUserDefaults(mode, forKey: .darkmode)
-        debugPrint("SettingsUseCase - changeDarkMode : \(mode)로 설정")
-        return Single.create { observer in
-            observer(.success(mode))
-            return Disposables.create()
-        }
+    func changeDarkMode(to mode: Int) {
+        DarkModeManager.shared.changeDarkMode(to: mode)
     }
 }

--- a/Segno/Segno/Domain/UseCase/SettingsUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/SettingsUseCase.swift
@@ -11,7 +11,7 @@ protocol SettingsUseCase {
     func getAutoPlayMode() -> Bool
     func changeAutoPlayMode(to mode: Bool)
     func getDarkMode() -> Int
-    func changeDarkMode(to mode: Int)
+    func changeDarkMode(to mode: Int) -> Single<Int>
 }
 
 final class SettingsUseCaseImpl: SettingsUseCase {
@@ -49,8 +49,12 @@ final class SettingsUseCaseImpl: SettingsUseCase {
         }
     }
     
-    func changeDarkMode(to mode: Int) {
+    func changeDarkMode(to mode: Int) -> Single<Int> {
         repository.setUserDefaults(mode, forKey: .darkmode)
         debugPrint("SettingsUseCase - changeDarkMode : \(mode)로 설정")
+        return Single.create { observer in
+            observer(.success(mode))
+            return Disposables.create()
+        }
     }
 }

--- a/Segno/Segno/Presentation/View/NicknameCell.swift
+++ b/Segno/Segno/Presentation/View/NicknameCell.swift
@@ -34,7 +34,7 @@ final class NicknameCell: UITableViewCell {
         let label = UILabel()
         label.text = Metric.nicknameLabelText
         label.font = .appFont(.surroundAir, size: Metric.textSize)
-        label.textColor = .appColor(.grey2)
+        label.textColor = .appColor(.grey3)
         return label
     }()
     

--- a/Segno/Segno/Presentation/ViewController/SettingsViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/SettingsViewController.swift
@@ -129,27 +129,15 @@ final class SettingsViewController: UIViewController {
                     let actionSheet = UIAlertController(title: Metric.darkModeSettingString, message: nil, preferredStyle: .actionSheet)
                     actionSheet.addAction(UIAlertAction(title: DarkMode.system.title, style: .default, handler: { _ in
                         self.viewModel.changeDarkMode(to: DarkMode.system.rawValue)
-                            .subscribe(onSuccess: { mode in
-                                self.view.window?.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mode) ?? .unspecified
-                                cell.configure(right: DarkMode.system.title)
-                            })
-                            .disposed(by: self.disposeBag)
+                        cell.configure(right: DarkMode.system.title)
                     }))
                     actionSheet.addAction(UIAlertAction(title: DarkMode.light.title, style: .default, handler: { _ in
                         self.viewModel.changeDarkMode(to: DarkMode.light.rawValue)
-                            .subscribe(onSuccess: { mode in
-                                self.view.window?.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mode) ?? .unspecified
-                                cell.configure(right: DarkMode.light.title)
-                            })
-                            .disposed(by: self.disposeBag)
+                        cell.configure(right: DarkMode.light.title)
                     }))
                     actionSheet.addAction(UIAlertAction(title: DarkMode.dark.title, style: .default, handler: { _ in
                         self.viewModel.changeDarkMode(to: DarkMode.dark.rawValue)
-                            .subscribe(onSuccess: { mode in
-                                self.view.window?.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mode) ?? .unspecified
-                                cell.configure(right: DarkMode.dark.title)
-                            })
-                            .disposed(by: self.disposeBag)
+                        cell.configure(right: DarkMode.dark.title)
                     }))
                     actionSheet.addAction(UIAlertAction(title: Metric.cancelMessage
                                                         , style: .cancel, handler: { _ in

--- a/Segno/Segno/Presentation/ViewController/SettingsViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/SettingsViewController.swift
@@ -21,6 +21,12 @@ enum SettingsCellActions: Int {
 }
 
 final class SettingsViewController: UIViewController {
+    private enum Metric {
+        static let settingString: String = "설정"
+        static let darkModeSettingString: String = "다크 모드 설정"
+        static let cancelMessage: String = "취소"
+    }
+    
     private let disposeBag = DisposeBag()
     private let viewModel: SettingsViewModel
     private lazy var tableView: UITableView = {
@@ -50,7 +56,7 @@ final class SettingsViewController: UIViewController {
     }
     
     private func setupView() {
-        title = "설정"
+        title = Metric.settingString
         view.backgroundColor = .appColor(.background)
     }
     
@@ -118,21 +124,38 @@ final class SettingsViewController: UIViewController {
                 guard let action = SettingsCellActions(rawValue: indexPath.row) else { return }
                 switch action {
                 case .darkmode: // 다크 모드 설정
-                    guard let cell = self?.tableView.cellForRow(at: indexPath) as? SettingsActionSheetCell else { return }
-                    let actionSheet = UIAlertController(title: "다크 모드 설정", message: nil, preferredStyle: .actionSheet)
+                    guard let cell = self?.tableView.cellForRow(at: indexPath) as? SettingsActionSheetCell,
+                          let self = self else { return }
+                    let actionSheet = UIAlertController(title: Metric.darkModeSettingString, message: nil, preferredStyle: .actionSheet)
                     actionSheet.addAction(UIAlertAction(title: DarkMode.system.title, style: .default, handler: { _ in
-                        self?.viewModel.changeDarkMode(to: DarkMode.system.rawValue)
-                        cell.configure(right: DarkMode.system.title)
+                        self.viewModel.changeDarkMode(to: DarkMode.system.rawValue)
+                            .subscribe(onSuccess: { mode in
+                                self.view.window?.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mode) ?? .unspecified
+                                cell.configure(right: DarkMode.system.title)
+                            })
+                            .disposed(by: self.disposeBag)
                     }))
                     actionSheet.addAction(UIAlertAction(title: DarkMode.light.title, style: .default, handler: { _ in
-                        self?.viewModel.changeDarkMode(to: DarkMode.light.rawValue)
-                        cell.configure(right: DarkMode.light.title)
+                        self.viewModel.changeDarkMode(to: DarkMode.light.rawValue)
+                            .subscribe(onSuccess: { mode in
+                                self.view.window?.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mode) ?? .unspecified
+                                cell.configure(right: DarkMode.light.title)
+                            })
+                            .disposed(by: self.disposeBag)
                     }))
                     actionSheet.addAction(UIAlertAction(title: DarkMode.dark.title, style: .default, handler: { _ in
-                        self?.viewModel.changeDarkMode(to: DarkMode.dark.rawValue)
-                        cell.configure(right: DarkMode.dark.title)
+                        self.viewModel.changeDarkMode(to: DarkMode.dark.rawValue)
+                            .subscribe(onSuccess: { mode in
+                                self.view.window?.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mode) ?? .unspecified
+                                cell.configure(right: DarkMode.dark.title)
+                            })
+                            .disposed(by: self.disposeBag)
                     }))
-                    self?.present(actionSheet, animated: true)
+                    actionSheet.addAction(UIAlertAction(title: Metric.cancelMessage
+                                                        , style: .cancel, handler: { _ in
+                        self.dismiss(animated: true)
+                    }))
+                    self.present(actionSheet, animated: true)
                 default:
                     break
                 }

--- a/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
@@ -42,7 +42,7 @@ final class SettingsViewModel {
         return settingsUseCase.getDarkMode()
     }
     
-    func changeDarkMode(to mode: Int) -> Single<Int> {
-        return settingsUseCase.changeDarkMode(to: mode)
+    func changeDarkMode(to mode: Int) {
+        settingsUseCase.changeDarkMode(to: mode)
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/SettingsViewModel.swift
@@ -42,7 +42,7 @@ final class SettingsViewModel {
         return settingsUseCase.getDarkMode()
     }
     
-    func changeDarkMode(to mode: Int) {
-        settingsUseCase.changeDarkMode(to: mode)
+    func changeDarkMode(to mode: Int) -> Single<Int> {
+        return settingsUseCase.changeDarkMode(to: mode)
     }
 }

--- a/Segno/Segno/Resource/Assets.xcassets/background.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/background.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.976",
-          "green" : "0.976",
-          "red" : "0.976"
+          "blue" : "0.114",
+          "green" : "0.114",
+          "red" : "0.114"
         }
       },
       "idiom" : "universal"

--- a/Segno/Segno/Resource/Assets.xcassets/grey1.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/grey1.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.929",
-          "green" : "0.929",
-          "red" : "0.929"
+          "blue" : "0.195",
+          "green" : "0.195",
+          "red" : "0.195"
         }
       },
       "idiom" : "universal"

--- a/Segno/Segno/Resource/Assets.xcassets/grey2.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/grey2.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.596",
-          "green" : "0.596",
-          "red" : "0.596"
+          "blue" : "0.240",
+          "green" : "0.240",
+          "red" : "0.240"
         }
       },
       "idiom" : "universal"

--- a/Segno/Segno/Resource/Assets.xcassets/grey3.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/grey3.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.400",
-          "green" : "0.400",
-          "red" : "0.400"
+          "blue" : "0.449",
+          "green" : "0.449",
+          "red" : "0.449"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
12/6 #157 #159 #160 

## 작업한 내용
### 다크모드 색상을 추가했습니다.
- 다크모드 설정시 보여줄 색상이 지정되어 있지 않아 추가했습니다.
### 다크모드 화면을 UserDefaults에 지정된 값에 따라 업데이트해주었습니다.
- 앱이 처음 실행될 때 SceneDelegate에서도 저장된 값에 따라 다크모드가 바로 설정될 수 있도록 DarkModeManager를 싱글톤으로 별도로 생성하였습니다.

## 고민한 점 및 어려웠던 점
### DarkModeManager를 유즈케이스에서 이용하는 것이 맞나 하는 고민을 했습니다.
- DarkModeManager는 LocalUtilityRepository로부터 UserDefaults값을 가져와 뷰를 직접적으로 업데이트해주는 역할을 수행합니다.
- SceneDelegate에서 다크모드 설정을 해주기 위한 고육책이었지만, DarkModeManager를 SettingUseCase에서 이용하는게 맞나 하는 고민을 했습니다. 유즈케이스가 유즈케이스를 이용하는 격이기 때문입니다. 
- 다만 이렇게 하지 않을 경우 코드의 일관성이 저하됩니다. 이로 인해 일단 유즈케이스에서 DarkModeManager을 이용하도록 작성해놓았습니다. 이부분에 대한 의견 부탁드립니다! 