### PR TITLE
DiaryCollectionViewController 검색 기능 구현

### DIFF
--- a/Segno/Segno/Data/Repository/DTO/DiaryListDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/DiaryListDTO.swift
@@ -37,9 +37,9 @@ struct DiaryListItemDTO: Decodable {
     static let exampleData2 = DiaryListItemDTO(identifier: "qwer", title: "예시 데이터2입니다.", thumbnailPath: "")
     static let exampleData3 = DiaryListItemDTO(identifier: "xzcv", title: "예시 데이터3입니다.", thumbnailPath: "")
     static let exampleData4 = DiaryListItemDTO(identifier: "hjkl", title: "예시 데이터4입니다.", thumbnailPath: "")
-    static let exampleData5 = DiaryListItemDTO(identifier: "sdfg", title: "예시 데이터5입니다.", thumbnailPath: "")
-    static let exampleData6 = DiaryListItemDTO(identifier: "wert", title: "예시 데이터6입니다.", thumbnailPath: "")
-    static let exampleData7 = DiaryListItemDTO(identifier: "xcvb", title: "예시 데이터7입니다.", thumbnailPath: "")
-    static let exampleData8 = DiaryListItemDTO(identifier: "ghjk", title: "예시 데이터8입니다.", thumbnailPath: "")
+    static let exampleData5 = DiaryListItemDTO(identifier: "sdfg", title: "테스트 데이터1입니다.", thumbnailPath: "")
+    static let exampleData6 = DiaryListItemDTO(identifier: "wert", title: "테스트 데이터2입니다.", thumbnailPath: "")
+    static let exampleData7 = DiaryListItemDTO(identifier: "xcvb", title: "테스트 데이터3입니다.", thumbnailPath: "")
+    static let exampleData8 = DiaryListItemDTO(identifier: "ghjk", title: "테스트 데이터4입니다.", thumbnailPath: "")
     #endif
 }


### PR DESCRIPTION
12/6 #118 

## 작업한 내용
### DiaryCollectionViewController의 검색 기능 구현
- 제목에 한하여서 검색 기능 구현

## 고민한 점 및 어려웠던 점
### SearchBar의 특성으로 textfiled가 비어있으면 검색도, 취소도 되지 않는 점
- 아래 gif를 첨부하였는데, 마지막에 보면 검색을 하고 모두 지운 상태에서는 검색 완료도 취소도 되지 않습니다
- 그래서 심지어 DiaryDetail로 넘어갔다 왔음에도 불구하고 여전히 검색창이 켜져있는 것(커서가 깜빡임)을 볼 수 있습니다
- tapGesture 등으로 다른 곳(collectionView?)이 선택되면 ```searchBar.endEditing(true)```로 강제종료를 하는게 최선인지 고민중입니다.

<img src="https://media.giphy.com/media/N5vDFthrlSEqCDts7M/giphy.gif">