### PR TITLE
DiaryEditViewController 터치, 키보드 관련 이슈 처리

### DIFF
--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -198,6 +198,17 @@ final class DiaryEditViewController: UIViewController {
         bindSearchResult()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        registerForKeyboardNotification()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        removeRegisterForKeyboardNotification()
+    }
     private func setupView() {
         view.backgroundColor = .appColor(.white)
         
@@ -296,8 +307,40 @@ final class DiaryEditViewController: UIViewController {
         mainScrollView.addGestureRecognizer(singleTapGestureRecognizer)
     }
     
-    @objc func singleTapMethod(sender: UITapGestureRecognizer) {
+    private func registerForKeyboardNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    private func removeRegisterForKeyboardNotification() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    private func keyboardAnimate(keyboardRectangle: CGRect ,textView: UITextView) {
+        let boundary = textView.frame.minY - mainScrollView.contentOffset.y - keyboardRectangle.height
+        if boundary > 0 {
+            mainScrollView.contentOffset = CGPoint(x: mainScrollView.contentOffset.x, y: boundary)
+        }
+    }
+    
+    @objc private func singleTapMethod(sender: UITapGestureRecognizer) {
         self.view.endEditing(true)
+    }
+    
+    
+    @objc private func keyboardHide(_ notification: Notification) {
+        self.view.transform = .identity
+    }
+    
+    @objc private func keyboardShow(notification: NSNotification) {
+        let userInfo: NSDictionary = notification.userInfo! as NSDictionary
+        let keyboardFrame: NSValue = userInfo.value(forKey: UIResponder.keyboardFrameEndUserInfoKey) as! NSValue
+        let keyboardRectangle = keyboardFrame.cgRectValue
+
+        if bodyTextView.isFirstResponder {
+            keyboardAnimate(keyboardRectangle: keyboardRectangle, textView: bodyTextView)
+        }
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -45,6 +45,7 @@ final class DiaryEditViewController: UIViewController {
     
     private lazy var mainScrollView: UIScrollView = {
         let scrollView = UIScrollView()
+        scrollView.keyboardDismissMode = .onDrag
         return scrollView
     }()
     

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -165,7 +165,8 @@ final class DiaryEditViewController: UIViewController {
         return button
     }()
     
-    private lazy var tapGesture = UITapGestureRecognizer()
+    
+    private lazy var photoImageViewTapGesture = UITapGestureRecognizer()
     
 //    // 뷰 모델이 작성되었을 경우, 위의 뷰 모델 프로퍼티 주석 해제와 함께 사용하면 됩니다.
 //    init(viewModel: DiaryEditViewModel
@@ -189,7 +190,7 @@ final class DiaryEditViewController: UIViewController {
         
         setupView()
         bindImageView()
-        
+        setRecognizer()
         // 샤잠킷 연동 메서드입니다. 향후 조정 예정입니다.
         bindLabel()
         bindButtonAction()
@@ -222,7 +223,7 @@ final class DiaryEditViewController: UIViewController {
         }
         
         contentsStackView.addArrangedSubview(photoImageView)
-        photoImageView.addGestureRecognizer(tapGesture)
+        
         photoImageView.snp.makeConstraints {
             $0.height.equalTo(Metric.majorContentHeight)
         }
@@ -259,7 +260,6 @@ final class DiaryEditViewController: UIViewController {
             $0.edges.equalTo(tagScrollView)
             $0.height.equalTo(tagScrollView)
         }
-        
         tagStackView.addArrangedSubview(addTagButton)
     }
     
@@ -280,11 +280,23 @@ final class DiaryEditViewController: UIViewController {
     }
     
     private func bindImageView() {
-        tapGesture.rx.event
+        photoImageView.isUserInteractionEnabled = true
+        photoImageView.addGestureRecognizer(photoImageViewTapGesture)
+        photoImageViewTapGesture.rx.event
             .bind(onNext: { recognizer in
+                self.view.endEditing(true)
                 print("gestures: \(recognizer.numberOfTouches)")
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func setRecognizer() {
+        let singleTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(singleTapMethod))
+        mainScrollView.addGestureRecognizer(singleTapGestureRecognizer)
+    }
+    
+    @objc func singleTapMethod(sender: UITapGestureRecognizer) {
+        self.view.endEditing(true)
     }
 }
 


### PR DESCRIPTION
12/6 #85 

## 작업한 내용
### TextView, TextField 이외의 곳 터치 시 키보드가 내려가야 하는데 ScrollView로 인해 touchesBegan을 호출할 수 없던 문제를 해결했습니다.
- ScrollView가 한 번의 터치는 먹어버리는 문제가 있었습니다.
- 이에 ScrollView에 UITapGestureRecognizer를 등록하고, 액션 함수 내부에 `self.view.endEditing(true)`를 작성하여 화면 터치 시 키보드가 내려가도록 했습니다.
- 
### 위를 처리해도 이미지뷰 터치가 안먹는 문제를 해결했습니다.
- photoImageView.isUserInteractionEnabled = true로 해결했습니다.

### 스크롤뷰를 스크롤시 키보드를 내리도록 설정했습니다.
### textView가 키보드에 가리지 않도록 처리했습니다.
- 다양한 경우의 수가 있어 애로가 많았습니다.

## 고민한 점 및 어려웠던 점
### textView가 키보드에 가리지 않도록 처리하는 것이 상당히 어려웠습니다.
- textView가 시중의 예제와는 달리 화면의 맨 밑에 있는 것이 아니라 중간에 위치합니다.
- 별다른 처리를 안해주면 스크롤의 위치가 맨 위일때는 키보드로 인해 텍스트뷰가 가려지지만,
- 이를 위해 뷰의 위치를 키보드 높이만큼 올려주는 식으로만 처리해버리면, 텍스트뷰가 화면 상의 상단에 위치할 때 터치 시 텍스트뷰가 화면을 벗어나게 됩니다.
- 이를 해결하려면 텍스트뷰의 슈퍼뷰상 위치(textView.frame.minY) , 스크롤뷰의 현재 화면 위치(mainScrollView.contentOffset.y), 키보드의 높이를 모두 고려해야 했습니다.
- 여러 번의 테스트 끝에 적절한 공식을 찾아내어 처리했습니다.

![Simulator Screen Recording - iPhone 14 Pro - 2022-12-07 at 02 29 47](https://user-images.githubusercontent.com/29617557/205981165-9369fe94-785e-44cb-af82-6fa4bd8c56b1.gif)
