### PR TITLE
뮤직 세션 레이어 분리

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */; };
 		4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D78292522B7005ABA8F /* BaseURL.swift */; };
 		4F4E0D7B29252526005ABA8F /* TokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7A29252526005ABA8F /* TokenDTO.swift */; };
+		4F51A6FD294096480039D86A /* PlayMusicUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F51A6FC294096480039D86A /* PlayMusicUseCase.swift */; };
 		4F5291DE293F065D00DF930A /* DiaryEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5291DD293F065D00DF930A /* DiaryEditViewModel.swift */; };
 		4F589DD6293FB9AB00DB39E5 /* ShazamSongDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F589DD5293FB9AB00DB39E5 /* ShazamSongDTO.swift */; };
 		4F589DD9293FBA0900DB39E5 /* ShazamError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F589DD8293FBA0900DB39E5 /* ShazamError.swift */; };
@@ -121,6 +122,7 @@
 		4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEndpoint.swift; sourceTree = "<group>"; };
 		4F4E0D78292522B7005ABA8F /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
 		4F4E0D7A29252526005ABA8F /* TokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDTO.swift; sourceTree = "<group>"; };
+		4F51A6FC294096480039D86A /* PlayMusicUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayMusicUseCase.swift; sourceTree = "<group>"; };
 		4F5291DD293F065D00DF930A /* DiaryEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditViewModel.swift; sourceTree = "<group>"; };
 		4F589DD5293FB9AB00DB39E5 /* ShazamSongDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShazamSongDTO.swift; sourceTree = "<group>"; };
 		4F589DD8293FBA0900DB39E5 /* ShazamError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShazamError.swift; sourceTree = "<group>"; };
@@ -337,6 +339,7 @@
 				9894EAF429373385005F2B15 /* SettingsUseCase.swift */,
 				4F307A49293889C200FA36A0 /* SearchMusicUseCase.swift */,
 				9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */,
+				4F51A6FC294096480039D86A /* PlayMusicUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -627,6 +630,7 @@
 				66A8CF612935F44100C17F84 /* MyPageViewModel.swift in Sources */,
 				988414D929235345007C9132 /* DiaryCollectionViewModel.swift in Sources */,
 				4F589DD6293FB9AB00DB39E5 /* ShazamSongDTO.swift in Sources */,
+				4F51A6FD294096480039D86A /* PlayMusicUseCase.swift in Sources */,
 				4FEBFAAF291CF9F300E78139 /* MusicInfo.swift in Sources */,
 				4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */,
 				7918380829233F7100BC6992 /* UIButton+.swift in Sources */,

--- a/Segno/Segno/Data/Network/Endpoints/DiaryDetailEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/DiaryDetailEndpoint.swift
@@ -19,7 +19,7 @@ enum DiaryDetailEndpoint: Endpoint {
     }
     
     var path: String {
-        return "items"
+        return "diary"
     }
     
     var parameters: HTTPRequestParameter? {

--- a/Segno/Segno/Data/Network/Endpoints/DiaryListItemEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/DiaryListItemEndpoint.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-// TODO: 서버 구현이 완료된 후 그에 맞게 바뀔 예정입니다.
 enum DiaryListItemEndpoint: Endpoint {
     case item
     
@@ -20,7 +19,7 @@ enum DiaryListItemEndpoint: Endpoint {
     }
     
     var path: String {
-        return "items"
+        return "diary"
     }
     
     var parameters: HTTPRequestParameter? {

--- a/Segno/Segno/Data/Repository/DTO/DiaryDetailDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/DiaryDetailDTO.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct DiaryDetailDTO: Decodable {
-    //TODO: MusicInfo, Location 추가 및 수정
     let id: String
     let title: String
     let tags: [String]
@@ -17,7 +16,13 @@ struct DiaryDetailDTO: Decodable {
     let musicInfo: MusicInfo?
     let location: Location?
     
-    init(id: String, title: String, tags: [String], imagePath: String, bodyText: String?, musicInfo: MusicInfo? = nil, location: Location? = nil) {
+    init(id: String,
+         title: String,
+         tags: [String],
+         imagePath: String,
+         bodyText: String? = nil,
+         musicInfo: MusicInfo? = nil,
+         location: Location? = nil) {
         self.id = id
         self.title = title
         self.tags = tags
@@ -25,6 +30,11 @@ struct DiaryDetailDTO: Decodable {
         self.bodyText = bodyText
         self.musicInfo = musicInfo
         self.location = location
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "_id"
+        case title, tags, imagePath, bodyText, musicInfo, location
     }
     
     #if DEBUG

--- a/Segno/Segno/Data/Repository/DTO/DiaryListDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/DiaryListDTO.swift
@@ -6,10 +6,10 @@
 //
 
 struct DiaryListDTO: Decodable {
-    let data: [DiaryListItemDTO]
+    let diaries: [DiaryListItemDTO]
     
     #if DEBUG
-    static let example = DiaryListDTO(data: [DiaryListItemDTO.exampleData1,
+    static let example = DiaryListDTO(diaries: [DiaryListItemDTO.exampleData1,
                                              DiaryListItemDTO.exampleData2,
                                              DiaryListItemDTO.exampleData3,
                                              DiaryListItemDTO.exampleData4,
@@ -21,7 +21,6 @@ struct DiaryListDTO: Decodable {
 }
 
 struct DiaryListItemDTO: Decodable {
-    // TODO: 일단은 다이어리 리스트 아이템과 동일하게 작성. 이후 서버 사이드에 따라 바꾸겠습니다.
     let identifier: String
     let title: String
     let thumbnailPath: String

--- a/Segno/Segno/Data/Repository/DiaryRepository.swift
+++ b/Segno/Segno/Data/Repository/DiaryRepository.swift
@@ -18,21 +18,21 @@ protocol DiaryRepository {
 
 final class DiaryRepositoryImpl: DiaryRepository {
     func getDiaryListItem() -> Single<DiaryListDTO> {
-//        let endpoint = DiaryListItemEndpoint.item
+        let endpoint = DiaryListItemEndpoint.item
+
+        return NetworkManager.shared.call(endpoint)
+            .map {
+                let diaryListItemDTO = try JSONDecoder().decode(DiaryListDTO.self, from: $0)
+                return diaryListItemDTO
+            }
 //
-//        return NetworkManager.shared.call(endpoint)
-//            .map {
-//                let diaryListItemDTO = try JSONDecoder().decode(DiaryListDTO.self, from: $0)
-//                return diaryListItemDTO
-//            }
-        
-        // TODO: 추후에 NetworkManager로 변경
-        return Single.create { observer -> Disposable in
-            let dto = DiaryListDTO.example
-            observer(.success(dto))
-            
-            return Disposables.create()
-        }
+//        // TODO: 추후에 NetworkManager로 변경
+//        return Single.create { observer -> Disposable in
+//            let dto = DiaryListDTO.example
+//            observer(.success(dto))
+//
+//            return Disposables.create()
+//        }
     }
     
     func getDiary(id: String) -> Single<DiaryDetailDTO> {

--- a/Segno/Segno/Data/Repository/DiaryRepository.swift
+++ b/Segno/Segno/Data/Repository/DiaryRepository.swift
@@ -39,7 +39,8 @@ final class DiaryRepositoryImpl: DiaryRepository {
         let endpoint = DiaryDetailEndpoint.item(id)
 
         return NetworkManager.shared.call(endpoint).map {
-            try JSONDecoder().decode(DiaryDetailDTO.self, from: $0)
+            debugPrint("repository: \($0)")
+            return try JSONDecoder().decode(DiaryDetailDTO.self, from: $0)
         }
         
 //        // TODO: 추후에 NetworkManager로 변경

--- a/Segno/Segno/Data/Repository/MusicRepository.swift
+++ b/Segno/Segno/Data/Repository/MusicRepository.swift
@@ -12,7 +12,9 @@ protocol MusicRepository {
     
     func startSearchingMusic()
     func stopSearchingMusic()
-    func playMusic()
+    func setupMusic(_ song: MusicInfo?)
+    func toggleMusicPlayer()
+    func stopPlayingMusic()
 }
 
 final class MusicRepositoryImpl: MusicRepository {
@@ -30,6 +32,10 @@ final class MusicRepositoryImpl: MusicRepository {
         subscribeSearchresult()
     }
     
+    func setupMusic(_ song: MusicInfo?) {
+        musicSession.fetchMusic(term: song)
+    }
+    
     func startSearchingMusic() {
         shazamSession.start()
     }
@@ -38,8 +44,12 @@ final class MusicRepositoryImpl: MusicRepository {
         shazamSession.stop()
     }
     
-    func playMusic() {
-        
+    func toggleMusicPlayer() {
+        musicSession.togglePlayer()
+    }
+    
+    func stopPlayingMusic() {
+        musicSession.stopMusic()
     }
 }
 

--- a/Segno/Segno/Data/Session/MusicSession.swift
+++ b/Segno/Segno/Data/Session/MusicSession.swift
@@ -8,8 +8,6 @@
 import MusicKit
 
 final class MusicSession {
-    private var song: Song?
-    
     private lazy var player = ApplicationMusicPlayer.shared
     private lazy var playerState = player.state
     
@@ -28,9 +26,8 @@ final class MusicSession {
                     let request = MusicCatalogResourceRequest<Song>(matching: \.isrc, equalTo: term.isrc)
                     let response = try await request.response()
                     if let item = response.items.first {
-                        song = item
+                        player.queue = [item]
                     }
-                    
                 } catch (let error) {
                     // TODO: 에러 처리
                     print(error.localizedDescription)
@@ -44,20 +41,14 @@ final class MusicSession {
     
     // 음악을 재생하는 함수
     func togglePlayer() {
-        guard let song else { return }
         if !isPlaying {
-            playMusic(song: song)
+            playMusic()
         } else {
             player.pause()
         }
-        
-        // 뷰 컨트롤러를 나갈 때 큐를 비워 준다.
-        // 뮤직세션, 샤잠세션은 싱글턴 인스턴스로 만들어 주는 것이 좋겠다.
     }
     
-    private func playMusic(song: Song) {
-        player.queue = [song]
-        
+    private func playMusic() {
         Task {
             do {
                 try await player.play()
@@ -70,5 +61,6 @@ final class MusicSession {
     
     func stopMusic() {
         player.stop()
+        player.queue = []
     }
 }

--- a/Segno/Segno/Domain/UseCase/DiaryDetailUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/DiaryDetailUseCase.swift
@@ -21,7 +21,14 @@ final class DiaryDetailUseCaseImpl: DiaryDetailUseCase {
     
     func getDiary(id: String) -> Single<DiaryDetail> {
         return repository.getDiary(id: id).map {
-            DiaryDetail(identifier: $0.id, title: $0.title, tags: $0.tags, imagePath: $0.imagePath, bodyText: $0.bodyText, musicInfo: nil, location: nil)
+            debugPrint("usecase: \($0)")
+            return DiaryDetail(identifier: $0.id,
+                               title: $0.title,
+                               tags: $0.tags,
+                               imagePath: $0.imagePath,
+                               bodyText: $0.bodyText,
+                               musicInfo: $0.musicInfo,
+                               location: $0.location)
             }
     }
 }

--- a/Segno/Segno/Domain/UseCase/DiaryListUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/DiaryListUseCase.swift
@@ -22,7 +22,7 @@ final class DiaryListUseCaseImpl: DiaryListUseCase {
     func getDiaryList() -> Single<[DiaryListItem]> {
         return repository.getDiaryListItem()
             .map {
-                $0.data.map { diaryData in
+                $0.diaries.map { diaryData in
                     DiaryListItem(identifier: diaryData.identifier, title: diaryData.title, thumbnailPath: diaryData.thumbnailPath)
                 }
             }

--- a/Segno/Segno/Domain/UseCase/PlayMusicUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/PlayMusicUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  PlayMusicUseCase.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/12/07.
+//
+
+import Foundation
+
+protocol PlayMusicUseCase {
+    func setupPlayer(_ song: MusicInfo?)
+    func togglePlayer()
+    func stopPlaying()
+}
+
+final class PlayMusicUseCaseImpl: PlayMusicUseCase {
+    let musicRepository: MusicRepository
+    
+    init(musicRepository: MusicRepository = MusicRepositoryImpl()) {
+        self.musicRepository = musicRepository
+    }
+    
+    func setupPlayer(_ song: MusicInfo?) {
+        musicRepository.setupMusic(song)
+    }
+    
+    func togglePlayer() {
+        musicRepository.toggleMusicPlayer()
+    }
+    
+    func stopPlaying() {
+        musicRepository.stopPlayingMusic()
+    }
+}

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -62,8 +62,6 @@ final class MusicContentView: UIView {
         super.init(frame: frame)
         
         setLayout()
-        // 임시로 정해진 데이터를 넣었습니다.
-        setMusic(info: MusicInfo.yokohama)
     }
     
     required init?(coder: NSCoder) {

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -118,9 +118,6 @@ final class DiaryDetailViewController: UIViewController {
         setupLayout()
         bindDiaryItem()
         getDiary()
-        
-        // 뮤직세션 테스트용으로, 임시로 정해진 데이터를 넣어 두었습니다.
-        musicSession.fetchMusic(term: MusicInfo.yokohama)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -222,6 +219,7 @@ final class DiaryDetailViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] musicInfo in
                 self?.musicContentView.setMusic(info: musicInfo)
+                self?.viewModel.setupMusicPlayer(musicInfo)
             })
             .disposed(by: disposeBag)
         

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -219,7 +219,6 @@ final class DiaryDetailViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] musicInfo in
                 self?.musicContentView.setMusic(info: musicInfo)
-                self?.viewModel.setupMusicPlayer(musicInfo)
             })
             .disposed(by: disposeBag)
         
@@ -241,6 +240,7 @@ final class DiaryDetailViewController: UIViewController {
 extension DiaryDetailViewController: MusicContentViewDelegate {
     func playButtonTapped() {
         musicSession.togglePlayer()
+//        viewModel.toggleMusicPlayer()
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -31,7 +31,6 @@ final class DiaryDetailViewController: UIViewController {
     }
     
     private let disposeBag = DisposeBag()
-    private let musicSession = MusicSession() // 임시로 여기에 놓습니다
     private let viewModel: DiaryDetailViewModel
     weak var delegate: DiaryDetailViewDelegate?
     
@@ -118,10 +117,12 @@ final class DiaryDetailViewController: UIViewController {
         setupLayout()
         bindDiaryItem()
         getDiary()
+        
+        viewModel.testDataInsert() // 임시 투입 메서드입니다.
     }
     
     override func viewWillDisappear(_ animated: Bool) {
-        musicSession.stopMusic()
+        viewModel.stopMusic()
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -239,8 +240,7 @@ final class DiaryDetailViewController: UIViewController {
 
 extension DiaryDetailViewController: MusicContentViewDelegate {
     func playButtonTapped() {
-        musicSession.togglePlayer()
-//        viewModel.toggleMusicPlayer()
+        viewModel.toggleMusicPlayer()
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -118,7 +118,7 @@ final class DiaryDetailViewController: UIViewController {
         bindDiaryItem()
         getDiary()
         
-        viewModel.testDataInsert() // 임시 투입 메서드입니다.
+//        viewModel.testDataInsert() // 임시 투입 메서드입니다.
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -34,7 +34,6 @@ final class DiaryDetailViewModel {
         self.playMusicUseCase = playMusicUseCase
         
         setupMusicPlayer()
-        testDataInsert()
     }
     
     func testDataInsert() {

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -12,7 +12,8 @@ import RxSwift
 final class DiaryDetailViewModel {
     
     private let itemIdentifier: String
-    let useCase: DiaryDetailUseCase
+    let getDetailUseCase: DiaryDetailUseCase
+    let playMusicUseCase: PlayMusicUseCase
     var diaryItem = PublishSubject<DiaryDetail>()
     // TODO: DiaryDetail에 date 추가
     // lazy var dateObservable = diaryItem.map { $0.date }
@@ -25,17 +26,32 @@ final class DiaryDetailViewModel {
         
     private let disposeBag = DisposeBag()
     
-    init(itemIdentifier: String, useCase: DiaryDetailUseCase = DiaryDetailUseCaseImpl()) {
+    init(itemIdentifier: String,
+         getDetailUseCase: DiaryDetailUseCase = DiaryDetailUseCaseImpl(),
+         playMusicUseCase: PlayMusicUseCase = PlayMusicUseCaseImpl()) {
         self.itemIdentifier = itemIdentifier
-        self.useCase = useCase
+        self.getDetailUseCase = getDetailUseCase
+        self.playMusicUseCase = playMusicUseCase
     }
     
     func getDiary() {
-        useCase.getDiary(id: itemIdentifier)
+        getDetailUseCase.getDiary(id: itemIdentifier)
             .subscribe(onSuccess: { [weak self] diary in
                 self?.diaryItem.onNext(diary)
             }, onFailure: { error in
                 print(error.localizedDescription)
             }).disposed(by: disposeBag)
+    }
+    
+    func setupMusicPlayer(_ song: MusicInfo?) {
+        playMusicUseCase.setupPlayer(song)
+    }
+    
+    func toggleMusicPlayer() {
+        playMusicUseCase.togglePlayer()
+    }
+    
+    func stopMusic() {
+        playMusicUseCase.stopPlaying()
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -32,6 +32,13 @@ final class DiaryDetailViewModel {
         self.itemIdentifier = itemIdentifier
         self.getDetailUseCase = getDetailUseCase
         self.playMusicUseCase = playMusicUseCase
+        
+        setupMusicPlayer()
+        testDataInsert()
+    }
+    
+    func testDataInsert() {
+        diaryItem.onNext(DiaryDetail.dummy)
     }
     
     func getDiary() {
@@ -43,8 +50,12 @@ final class DiaryDetailViewModel {
             }).disposed(by: disposeBag)
     }
     
-    func setupMusicPlayer(_ song: MusicInfo?) {
-        playMusicUseCase.setupPlayer(song)
+    func setupMusicPlayer() {
+        musicObservable
+            .subscribe(onNext: {
+                self.playMusicUseCase.setupPlayer($0)
+            })
+            .disposed(by: disposeBag)
     }
     
     func toggleMusicPlayer() {


### PR DESCRIPTION
12/7 #90 #142 #156 

## 작업한 내용
### MusicSession 객체를 클린 아키텍처를 지향하여 분리하였습니다.
- Repository에서 재생 요청을 보내게 됩니다.
- 음악 플레이어는 뷰와 무관한 객체고, 직접 기기의 미디어 재생 수단과 연결되기 때문에 이렇게 하는 것이 가능합니다.
### 덤 : 서버와 일기 리스트 뷰를 연결했습니다.
- 음악 재생을 테스트하기 위해 구조를 뜯다가 수행했습니다.
### 덤 : 서버와 일기 상세 뷰를 연결했습니다.
- 일기 목록 URL에 쿼리만 붙여주면 되더군요..?

## 고민한 점 및 어려웠던 점
### MusicContentsView의 재생/일시정지 상태에 따라 UI를 업데이트해야 할 듯 합니다.
- 이를 위해 뷰 모델에 재생중이냐 아니냐를 나타내는 프로퍼티는 있어야 할 것 같습니다.
### 한곡반복은 어떻게 해야 할지 고민했습니다.
- 일기를 보는 동안은 무한 반복이 돼야 하는데, 그것은 아직 구현하지 못했습니다.
