### PR TITLE
Alert 팝업을 위한 extension 작성

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		4F4E0D7629252236005ABA8F /* LoginEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */; };
 		4F4E0D79292522B7005ABA8F /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D78292522B7005ABA8F /* BaseURL.swift */; };
 		4F4E0D7B29252526005ABA8F /* TokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4E0D7A29252526005ABA8F /* TokenDTO.swift */; };
+		4F51A6FF2940FE810039D86A /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F51A6FE2940FE810039D86A /* UIViewController+.swift */; };
 		4F5291DE293F065D00DF930A /* DiaryEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5291DD293F065D00DF930A /* DiaryEditViewModel.swift */; };
 		4F589DD6293FB9AB00DB39E5 /* ShazamSongDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F589DD5293FB9AB00DB39E5 /* ShazamSongDTO.swift */; };
 		4F589DD9293FBA0900DB39E5 /* ShazamError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F589DD8293FBA0900DB39E5 /* ShazamError.swift */; };
@@ -121,6 +122,7 @@
 		4F4E0D7529252236005ABA8F /* LoginEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEndpoint.swift; sourceTree = "<group>"; };
 		4F4E0D78292522B7005ABA8F /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
 		4F4E0D7A29252526005ABA8F /* TokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDTO.swift; sourceTree = "<group>"; };
+		4F51A6FE2940FE810039D86A /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4F5291DD293F065D00DF930A /* DiaryEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditViewModel.swift; sourceTree = "<group>"; };
 		4F589DD5293FB9AB00DB39E5 /* ShazamSongDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShazamSongDTO.swift; sourceTree = "<group>"; };
 		4F589DD8293FBA0900DB39E5 /* ShazamError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShazamError.swift; sourceTree = "<group>"; };
@@ -322,6 +324,7 @@
 				791837FE292225DC00BC6992 /* UIFont+.swift */,
 				4FEBFAB0291CFB5500E78139 /* SHMediaItem+.swift */,
 				7918380729233F7100BC6992 /* UIButton+.swift */,
+				4F51A6FE2940FE810039D86A /* UIViewController+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -616,6 +619,7 @@
 				66A8CF6B2937947A00C17F84 /* UserDetailDTO.swift in Sources */,
 				4F9A001B292227D7007D9057 /* NetworkManager.swift in Sources */,
 				9894EAF529373385005F2B15 /* SettingsUseCase.swift in Sources */,
+				4F51A6FF2940FE810039D86A /* UIViewController+.swift in Sources */,
 				4F5291DE293F065D00DF930A /* DiaryEditViewModel.swift in Sources */,
 				9841D6172925FACC00318EA9 /* LoginUseCase.swift in Sources */,
 				66A8CF6D29379A9900C17F84 /* UserDetailEndpoint.swift in Sources */,

--- a/Segno/Segno/Extension/UIViewController+.swift
+++ b/Segno/Segno/Extension/UIViewController+.swift
@@ -8,11 +8,22 @@
 import UIKit
 
 extension UIViewController {
-    func makeOKAlert(title: String, message: String, completion: @escaping () -> Void) {
+    // OK를 누르면 소멸하고 아무것도 하지 않는 얼럿입니다.
+    func makeOKAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .cancel, handler: nil)
         alert.addAction(action)
-        self.present(alert, animated: true, completion: completion)
+        present(alert, animated: true)
     }
     
+    // 캔슬과 OK가 있는 얼럿입니다. OK에서 수행해 줄 액션을 action에 작성해주면 될 것으로 기대합니다.
+    func makeCancelOKAlert(title: String, message: String, action: @escaping (UIAlertAction) -> Void) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        let okAction = UIAlertAction(title: "OK", style: .default, handler: action)
+        
+        alert.addAction(cancelAction)
+        alert.addAction(okAction)
+        present(alert, animated: true)
+    }
 }

--- a/Segno/Segno/Extension/UIViewController+.swift
+++ b/Segno/Segno/Extension/UIViewController+.swift
@@ -1,0 +1,18 @@
+//
+//  UIViewController+.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/12/08.
+//
+
+import UIKit
+
+extension UIViewController {
+    func makeOKAlert(title: String, message: String, completion: @escaping () -> Void) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let action = UIAlertAction(title: "OK", style: .cancel, handler: nil)
+        alert.addAction(action)
+        self.present(alert, animated: true, completion: completion)
+    }
+    
+}


### PR DESCRIPTION
12/8

## 작업한 내용
### UIViewController의 extension으로, 얼럿 팝업을 띄워 주는 메서드를 작성했습니다.
- 기본적으로 제목과 메시지를 입력합니다.
- OK만 있는 팝업, Cancel과 OK가 있는 팝업을 구현했습니다.
    - 후자의 경우, action 파라미터가 있고, OK를 눌렀을 때의 동작을 클로저 안에 넣어 주면 됩니다.

---

사용 예시

``` swift
class ViewController {
    private func searchTapped() {
//        shazamSession.toggleSearch()
        makeCancelOKAlert(title: "검색한다", message: "진짜 한다") { _ in
            self.shazamSession.toggleSearch()
        }
    }
}
```
