### PR TITLE
DiaryEditViewController 구성 / Location 흐름 구축

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		7940FB33292E065F00276EFC /* DiaryDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */; };
 		79767E64293E2A1200E489DD /* DiaryDeleteEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */; };
 		98003E0E293F20F6009FBC35 /* DarkModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98003E0D293F20F6009FBC35 /* DarkModeManager.swift */; };
+		98138D292940B00900D2CEDF /* DeleteTapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98138D282940B00900D2CEDF /* DeleteTapGestureRecognizer.swift */; };
 		9825F41B29377875005F2163 /* ChangeNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */; };
 		9825F41D29377ACF005F2163 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41C29377ACF005F2163 /* SettingsRepository.swift */; };
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
@@ -170,6 +171,7 @@
 		7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiaryDetailUseCase.swift; sourceTree = "<group>"; };
 		79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDeleteEndpoint.swift; sourceTree = "<group>"; };
 		98003E0D293F20F6009FBC35 /* DarkModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeManager.swift; sourceTree = "<group>"; };
+		98138D282940B00900D2CEDF /* DeleteTapGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTapGestureRecognizer.swift; sourceTree = "<group>"; };
 		9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameUseCase.swift; sourceTree = "<group>"; };
 		9825F41C29377ACF005F2163 /* SettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepository.swift; sourceTree = "<group>"; };
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
@@ -509,6 +511,7 @@
 			isa = PBXGroup;
 			children = (
 				9894EAF729375281005F2B15 /* DarkMode.swift */,
+				98138D282940B00900D2CEDF /* DeleteTapGestureRecognizer.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -602,6 +605,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				98138D292940B00900D2CEDF /* DeleteTapGestureRecognizer.swift in Sources */,
 				98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */,
 				791529DE29333D40005A8DDB /* ImageEndpoint.swift in Sources */,
 				4F4E0D3E2924B925005ABA8F /* LoginRepository.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		79767E64293E2A1200E489DD /* DiaryDeleteEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */; };
 		98003E0E293F20F6009FBC35 /* DarkModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98003E0D293F20F6009FBC35 /* DarkModeManager.swift */; };
 		98138D292940B00900D2CEDF /* DeleteTapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98138D282940B00900D2CEDF /* DeleteTapGestureRecognizer.swift */; };
+		98138D2B2940EA0800D2CEDF /* LocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98138D2A2940EA0800D2CEDF /* LocationRepository.swift */; };
+		98138D4D2940F53F00D2CEDF /* LocationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98138D4C2940F53F00D2CEDF /* LocationUseCase.swift */; };
 		9825F41B29377875005F2163 /* ChangeNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */; };
 		9825F41D29377ACF005F2163 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9825F41C29377ACF005F2163 /* SettingsRepository.swift */; };
 		982A2A472924AE74006F6ACD /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */; };
@@ -172,6 +174,8 @@
 		79767E63293E2A1200E489DD /* DiaryDeleteEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDeleteEndpoint.swift; sourceTree = "<group>"; };
 		98003E0D293F20F6009FBC35 /* DarkModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeManager.swift; sourceTree = "<group>"; };
 		98138D282940B00900D2CEDF /* DeleteTapGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTapGestureRecognizer.swift; sourceTree = "<group>"; };
+		98138D2A2940EA0800D2CEDF /* LocationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationRepository.swift; sourceTree = "<group>"; };
+		98138D4C2940F53F00D2CEDF /* LocationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationUseCase.swift; sourceTree = "<group>"; };
 		9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameUseCase.swift; sourceTree = "<group>"; };
 		9825F41C29377ACF005F2163 /* SettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepository.swift; sourceTree = "<group>"; };
 		982A2A462924AE74006F6ACD /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
@@ -335,6 +339,7 @@
 				988414DA2923606B007C9132 /* DiaryListUseCase.swift */,
 				7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */,
 				791529D72932F364005A8DDB /* DiaryEditUseCase.swift */,
+				98138D4C2940F53F00D2CEDF /* LocationUseCase.swift */,
 				66A8CF682937945300C17F84 /* UserDetailUseCase.swift */,
 				9894EAF429373385005F2B15 /* SettingsUseCase.swift */,
 				4F307A49293889C200FA36A0 /* SearchMusicUseCase.swift */,
@@ -476,6 +481,7 @@
 				4FCAC5C1292B5C9000BF9CDD /* LoginSession.swift */,
 				4F307A4529387C1100FA36A0 /* ShazamSession.swift */,
 				4F307A472938832900FA36A0 /* MusicSession.swift */,
+				98138D2A2940EA0800D2CEDF /* LocationRepository.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -629,11 +635,13 @@
 				66A8CF692937945300C17F84 /* UserDetailUseCase.swift in Sources */,
 				988414AE2922235B007C9132 /* LocalUtilityRepository.swift in Sources */,
 				66A8CF612935F44100C17F84 /* MyPageViewModel.swift in Sources */,
+				98138D4D2940F53F00D2CEDF /* LocationUseCase.swift in Sources */,
 				988414D929235345007C9132 /* DiaryCollectionViewModel.swift in Sources */,
 				4F589DD6293FB9AB00DB39E5 /* ShazamSongDTO.swift in Sources */,
 				4FEBFAAF291CF9F300E78139 /* MusicInfo.swift in Sources */,
 				4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */,
 				7918380829233F7100BC6992 /* UIButton+.swift in Sources */,
+				98138D2B2940EA0800D2CEDF /* LocationRepository.swift in Sources */,
 				4F4E0D7B29252526005ABA8F /* TokenDTO.swift in Sources */,
 				666E6F81291CF49E00CECD4B /* LoginCoordinator.swift in Sources */,
 				7940FB31292E065100276EFC /* DiaryDetailEndpoint.swift in Sources */,
@@ -832,6 +840,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 받아오기 위해 권한이 필요합니다.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음악 검색 기능을 위해 마이크 사용 허가가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -863,6 +872,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 받아오기 위해 권한이 필요합니다.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음악 검색 기능을 위해 마이크 사용 허가가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/Segno/Segno/Application/AppCoordinator.swift
+++ b/Segno/Segno/Application/AppCoordinator.swift
@@ -18,9 +18,9 @@ final class AppCoordinator: Coordinator {
     
     func start() {
         // TODO: login이 안되어있으면 LoginCoordinator 실행
-        startLoginCoordinator()
+//        startLoginCoordinator()
         // TODO: login이 되어있으면 TabBarCoordinator 실행
-//        startTabBarCoordinator()
+        startTabBarCoordinator()
     }
     
     func startLoginCoordinator() {

--- a/Segno/Segno/Data/Session/LocationRepository.swift
+++ b/Segno/Segno/Data/Session/LocationRepository.swift
@@ -1,0 +1,81 @@
+//
+//  LocationSession.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/12/08.
+//
+
+import CoreLocation
+import Foundation
+
+import RxSwift
+
+protocol LocationRepository {
+    var locationSubject: PublishSubject<Location> { get set }
+    var addressSubject: PublishSubject<String> { get set }
+    func getLocation()
+    func stopLocation()
+}
+
+final class LocationRepositoryImpl: NSObject, LocationRepository {
+    var locationSubject = PublishSubject<Location>()
+    var addressSubject = PublishSubject<String>()
+    private var locationManager = CLLocationManager()
+    
+    override init() {
+        
+    }
+    
+    func getLocation() {
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.requestWhenInUseAuthorization()
+        DispatchQueue.global().async {
+            if CLLocationManager.locationServicesEnabled() {
+                debugPrint("위치 서비스 on")
+                self.locationManager.startUpdatingLocation()
+            } else {
+                print("위치 서비스 off 상태")
+            }
+        }
+    }
+    
+    func stopLocation() {
+        DispatchQueue.global().async {
+            self.locationManager.stopUpdatingLocation()
+        }
+    }
+    
+    func getAddress(location: CLLocation) {
+        let geocoder = CLGeocoder()
+        let locale = Locale(identifier: "Ko-kr")
+        geocoder.reverseGeocodeLocation(location, preferredLocale: locale) { placemarks, error in
+            guard let placemarks = placemarks,
+                  let address = placemarks.last else { return }
+//            debugPrint("description : ", address.description)
+            let fullAddress = address.description.components(separatedBy: ", ")[1]
+            let array = Array(fullAddress.components(separatedBy: " ").dropFirst())
+            let refinedAddress = array.joined(separator: " ")
+            debugPrint("full : ", refinedAddress)
+            
+            self.addressSubject.onNext(refinedAddress)
+        }
+    }
+}
+
+extension LocationRepositoryImpl: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        debugPrint("didUpdateLocations")
+        if let cllocation = locations.first {
+            print("위도 : \(cllocation.coordinate.latitude)")
+            print("경도 : \(cllocation.coordinate.longitude)")
+            let location = Location(latitude: cllocation.coordinate.latitude, longitude: cllocation.coordinate.longitude)
+            getAddress(location: cllocation)
+            locationSubject.onNext(location)
+        }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        debugPrint("didFailWithError")
+    }
+}

--- a/Segno/Segno/Domain/UseCase/LocationUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/LocationUseCase.swift
@@ -1,0 +1,47 @@
+//
+//  LocationUseCase.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/12/08.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol LocationUseCase {
+    var locationSubject: PublishSubject<Location> { get set }
+    var addressSubject: PublishSubject<String> { get set }
+    func getLocation()
+    func stopLocation()
+}
+
+final class LocationUseCaseImpl: LocationUseCase {
+    var locationSubject = PublishSubject<Location>()
+    var addressSubject = PublishSubject<String>()
+    let repository: LocationRepository
+    private let disposeBag = DisposeBag()
+    
+    init(repository: LocationRepository = LocationRepositoryImpl()) {
+        self.repository = repository
+        subscribeResults()
+    }
+    
+    func getLocation() {
+        repository.getLocation()
+    }
+    
+    func stopLocation() {
+        repository.stopLocation()
+    }
+    
+    private func subscribeResults() {
+        repository.addressSubject
+            .bind(to: addressSubject)
+            .disposed(by: disposeBag)
+        
+        repository.locationSubject
+            .bind(to: locationSubject)
+            .disposed(by: disposeBag)
+    }
+}

--- a/Segno/Segno/Presentation/Utility/DeleteTapGestureRecognizer.swift
+++ b/Segno/Segno/Presentation/Utility/DeleteTapGestureRecognizer.swift
@@ -1,0 +1,13 @@
+//
+//  DeleteTapGestureRecognizer.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/12/07.
+//
+
+import UIKit
+
+class DeleteGestureRecognizer: UITapGestureRecognizer {
+    var title: String?
+}
+

--- a/Segno/Segno/Presentation/View/TagView.swift
+++ b/Segno/Segno/Presentation/View/TagView.swift
@@ -15,7 +15,7 @@ final class TagView: UIView {
         static let cornerRadius: CGFloat = 15
     }
 
-    private lazy var tagLabel: UILabel = {
+    lazy var tagLabel: UILabel = {
         let label = UILabel()
         label.font = .appFont(.surround, size: Metric.tagFontSize)
         label.textColor = .appColor(.white)
@@ -34,7 +34,7 @@ final class TagView: UIView {
     
     private func setupLayout(tagTitle: String) {
         addSubview(tagLabel)
-        backgroundColor = .appColor(.color3)
+        backgroundColor = .appColor(.color4)
         layer.cornerRadius = Metric.cornerRadius
         
         tagLabel.text = tagTitle

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -28,14 +28,16 @@ final class DiaryEditViewController: UIViewController {
         static let mediumFontSize: CGFloat = 24
         static let smallFontSize: CGFloat = 16
         static let textFieldFontSize: CGFloat = 12
+        static let padding: CGFloat = 12
         static let titlePlaceholder = "제목을 입력하세요."
+        static let bodyPlaceholder = "내용을 입력하세요."
         static let musicPlaceholder = "지금 이 음악은 뭘까요?"
         static let searching = "검색 중입니다..."
         static let musicNotFound = "음악을 찾지 못했어요."
         static let locationPlaceholder = "여기는 어디인가요?"
         static let tagPlaceholder = "태그를 입력해주세요. enter로 태그를 구분합니다."
         static let imageViewStockImage = UIImage(systemName: "photo")
-        static let leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 12.0, height: 0.0))
+        static let leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: padding, height: 0.0))
         // 스택 뷰 안에 들어가는 버튼 설정
         static let musicButtonImage = UIImage(systemName: "music.note")
         static let locationButtonImage = UIImage(systemName: "location.fill")
@@ -84,9 +86,13 @@ final class DiaryEditViewController: UIViewController {
         let textView = UITextView()
         textView.backgroundColor = .appColor(.color2)
         textView.font = .appFont(.shiningStar, size: Metric.mediumFontSize)
+        textView.text = Metric.bodyPlaceholder
+        textView.textColor = .appColor(.grey3)
         textView.layer.borderColor = UIColor.appColor(.color4)?.cgColor
         textView.layer.borderWidth = 1
         textView.layer.cornerRadius = Metric.standardCornerRadius
+        textView.textContainerInset = .init(top: Metric.padding, left: Metric.padding, bottom: Metric.padding, right: Metric.padding)
+        textView.delegate = self
         return textView
     }()
     
@@ -457,7 +463,7 @@ extension DiaryEditViewController: UITextFieldDelegate {
             
             tags.append(tagText)
             tagStackView.addArrangedSubview(tagView)
-            tagTextField.text = ""
+            tagTextField.text = nil
         }
         return true
     }
@@ -475,6 +481,23 @@ extension DiaryEditViewController: UITextFieldDelegate {
         
         tagStackView.removeArrangedSubview(tagView)
         tagView.removeFromSuperview()
+    }
+}
+
+extension DiaryEditViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        print("진입 : ", textView.text)
+        if textView.text == Metric.bodyPlaceholder {
+            textView.text = nil
+            textView.textColor = .appColor(.black)
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            textView.text = Metric.bodyPlaceholder
+            textView.textColor = .appColor(.grey3)
+        }
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -126,10 +126,12 @@ final class DiaryEditViewController: UIViewController {
     private lazy var musicStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.backgroundColor = .appColor(.color1)
+        stackView.backgroundColor = .appColor(.grey1)
         stackView.distribution = .equalSpacing
-        stackView.layer.cornerRadius = Metric.standardCornerRadius
+        stackView.layer.cornerRadius = Metric.buttonCornerRadius
         stackView.spacing = Metric.doubleSpacing
+        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: Metric.padding)
+        stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
     
@@ -137,6 +139,7 @@ final class DiaryEditViewController: UIViewController {
         let button = UIButton()
         button.backgroundColor = .appColor(.color3)
         button.layer.cornerRadius = Metric.buttonCornerRadius
+        button.tintColor = .appColor(.white)
         button.setImage(Metric.musicButtonImage, for: .normal)
         return button
     }()
@@ -152,17 +155,20 @@ final class DiaryEditViewController: UIViewController {
     private lazy var locationStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.backgroundColor = .appColor(.color1)
+        stackView.backgroundColor = .appColor(.grey1)
         stackView.distribution = .equalSpacing
-        stackView.layer.cornerRadius = Metric.standardCornerRadius
+        stackView.layer.cornerRadius = Metric.buttonCornerRadius
         stackView.spacing = Metric.doubleSpacing
+        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: Metric.padding)
+        stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
     
     private lazy var addlocationButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = .appColor(.color3) // 테스트용 색상..?
+        button.backgroundColor = .appColor(.color3)
         button.layer.cornerRadius = Metric.buttonCornerRadius
+        button.tintColor = .appColor(.white)
         button.setImage(Metric.locationButtonImage, for: .normal)
         return button
     }()
@@ -222,7 +228,7 @@ final class DiaryEditViewController: UIViewController {
     }
     
     private func setupView() {
-        view.backgroundColor = .appColor(.white)
+        view.backgroundColor = .appColor(.background)
         
         view.addSubview(mainScrollView)
         mainScrollView.snp.makeConstraints {

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -71,6 +71,7 @@ final class DiaryEditViewController: UIViewController {
         imageView.backgroundColor = .appColor(.color4)
         imageView.contentMode = .scaleAspectFit
         imageView.image = Metric.imageViewStockImage
+        imageView.tintColor = .appColor(.white)
         imageView.layer.cornerRadius = Metric.standardCornerRadius
         return imageView
     }()
@@ -167,8 +168,9 @@ final class DiaryEditViewController: UIViewController {
         return button
     }()
     
-    
     private lazy var photoImageViewTapGesture = UITapGestureRecognizer()
+    
+    private let imagePicker = UIImagePickerController()
     
     init(viewModel: DiaryEditViewModel = DiaryEditViewModel()) {
         self.viewModel = viewModel
@@ -185,6 +187,7 @@ final class DiaryEditViewController: UIViewController {
         
         setupView()
         bindImageView()
+        setImagePicker()
         setRecognizer()
         bindButtonAction()
         subscribeSearchingStatus()
@@ -290,9 +293,15 @@ final class DiaryEditViewController: UIViewController {
         photoImageViewTapGesture.rx.event
             .bind(onNext: { recognizer in
                 self.view.endEditing(true)
-                print("gestures: \(recognizer.numberOfTouches)")
+                self.present(self.imagePicker, animated: true)
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func setImagePicker() {
+        imagePicker.sourceType = .photoLibrary
+        imagePicker.allowsEditing = true
+        imagePicker.delegate = self
     }
     
     private func setRecognizer() {
@@ -383,6 +392,21 @@ extension DiaryEditViewController {
     
     private func searchTapped() {
         viewModel.toggleSearchMusic()
+    }
+}
+
+extension DiaryEditViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        var newImage: UIImage? = nil // update 할 이미지
+        
+        if let possibleImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
+            newImage = possibleImage // 수정된 이미지가 있을 경우
+        } else if let possibleImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+            newImage = possibleImage // 원본 이미지가 있을 경우
+        }
+        photoImageView.backgroundColor = .clear
+        photoImageView.image = newImage // 받아온 이미지를 update
+        dismiss(animated: true)
     }
 }
 


### PR DESCRIPTION
12/7 #166 #168 #171

## 작업한 내용
### imagePicker를 통해 갤러리의 이미지를 선택하고, 뷰에 반영될 수 있도록 했습니다.
### 태그 추가 시 적절한 UI 형태로 반환하도록 했습니다.
- 이 과정에서 텍스트필드를 새롭게  작성했으며, 관련하여 키보드 가림 이슈를 다시 수정했습니다.
### 위치 버튼을 눌렀을 때 레포지토리를 통해 위치를 가져오는 일련의 흐름을 구축했습니다.
- 뷰컨트롤러를 제공할 필요가 없어, session이 아닌 일반적인 클린 아키텍처 흐름으로 구성했습니다.
<img width="346" alt="image" src="https://user-images.githubusercontent.com/29617557/206288471-56ff7eb4-3155-4275-96c3-08c2f648d98b.png">
