### PR TITLE
전체적인 Location 관련 로직 수정

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		988414DB2923606B007C9132 /* DiaryListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988414DA2923606B007C9132 /* DiaryListUseCase.swift */; };
 		9894EAF529373385005F2B15 /* SettingsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9894EAF429373385005F2B15 /* SettingsUseCase.swift */; };
 		9894EAF829375281005F2B15 /* DarkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9894EAF729375281005F2B15 /* DarkMode.swift */; };
+		98AE6A88294450520039A666 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE6A87294450520039A666 /* MapViewModel.swift */; };
+		98AE6A8A29445F2A0039A666 /* GetAddressUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE6A8929445F2A0039A666 /* GetAddressUseCase.swift */; };
 		98B5263E292CA46C00446413 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263D292CA46C00446413 /* TagView.swift */; };
 		98B52640292CB92900446413 /* MusicContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5263F292CB92900446413 /* MusicContentView.swift */; };
 		98B5EF342941B85A00287405 /* ImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5EF332941B85A00287405 /* ImageUseCase.swift */; };
@@ -111,7 +113,7 @@
 		98BEE3702934A19800B20143 /* SettingsSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BEE36F2934A19800B20143 /* SettingsSwitchCell.swift */; };
 		98F5AD2A292DDDEB00E53E25 /* LocationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */; };
 		98FDF8A1292F56580083FA05 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A0292F56580083FA05 /* Location.swift */; };
-		98FDF8A3292F5CCA0083FA05 /* MapKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */; };
+		98FDF8A3292F5CCA0083FA05 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A2292F5CCA0083FA05 /* MapViewController.swift */; };
 		98FDF8A5292F7A350083FA05 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDF8A4292F7A350083FA05 /* UIView+.swift */; };
 /* End PBXBuildFile section */
 
@@ -208,6 +210,8 @@
 		988414DA2923606B007C9132 /* DiaryListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListUseCase.swift; sourceTree = "<group>"; };
 		9894EAF429373385005F2B15 /* SettingsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUseCase.swift; sourceTree = "<group>"; };
 		9894EAF729375281005F2B15 /* DarkMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkMode.swift; sourceTree = "<group>"; };
+		98AE6A87294450520039A666 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
+		98AE6A8929445F2A0039A666 /* GetAddressUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressUseCase.swift; sourceTree = "<group>"; };
 		98B5263D292CA46C00446413 /* TagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagView.swift; sourceTree = "<group>"; };
 		98B5263F292CB92900446413 /* MusicContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicContentView.swift; sourceTree = "<group>"; };
 		98B5EF332941B85A00287405 /* ImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUseCase.swift; sourceTree = "<group>"; };
@@ -217,7 +221,7 @@
 		98BEE36F2934A19800B20143 /* SettingsSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSwitchCell.swift; sourceTree = "<group>"; };
 		98F5AD29292DDDEB00E53E25 /* LocationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationContentView.swift; sourceTree = "<group>"; };
 		98FDF8A0292F56580083FA05 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
-		98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapKitViewController.swift; sourceTree = "<group>"; };
+		98FDF8A2292F5CCA0083FA05 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		98FDF8A4292F7A350083FA05 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -367,6 +371,7 @@
 				7940FB32292E065F00276EFC /* DiaryDetailUseCase.swift */,
 				791529D72932F364005A8DDB /* DiaryEditUseCase.swift */,
 				98138D4C2940F53F00D2CEDF /* LocationUseCase.swift */,
+				98AE6A8929445F2A0039A666 /* GetAddressUseCase.swift */,
 				66A8CF682937945300C17F84 /* UserDetailUseCase.swift */,
 				9894EAF429373385005F2B15 /* SettingsUseCase.swift */,
 				4F307A49293889C200FA36A0 /* SearchMusicUseCase.swift */,
@@ -384,6 +389,7 @@
 				982B3B7E292E68FB0077A44B /* DiaryDetailViewModel.swift */,
 				4F5291DD293F065D00DF930A /* DiaryEditViewModel.swift */,
 				988414D829235345007C9132 /* DiaryCollectionViewModel.swift */,
+				98AE6A87294450520039A666 /* MapViewModel.swift */,
 				983AE9D72935CEE2006547BD /* SettingsViewModel.swift */,
 				66A8CF602935F44100C17F84 /* MyPageViewModel.swift */,
 			);
@@ -398,7 +404,7 @@
 				982A3698292C905300FDC6CF /* DiaryDetailViewController.swift */,
 				4FA05B96292DFCCC00AFB020 /* DiaryEditViewController.swift */,
 				666E6F8D291CFADD00CECD4B /* MyPageViewController.swift */,
-				98FDF8A2292F5CCA0083FA05 /* MapKitViewController.swift */,
+				98FDF8A2292F5CCA0083FA05 /* MapViewController.swift */,
 				6692A9EE292F605E00DDA835 /* SettingsViewController.swift */,
 			);
 			path = ViewController;
@@ -665,6 +671,7 @@
 				9841D6172925FACC00318EA9 /* LoginUseCase.swift in Sources */,
 				66A8CF6D29379A9900C17F84 /* UserDetailEndpoint.swift in Sources */,
 				4FEBFAAD291CF62E00E78139 /* DiaryDetail.swift in Sources */,
+				98AE6A88294450520039A666 /* MapViewModel.swift in Sources */,
 				4FEBFAB1291CFB5500E78139 /* SHMediaItem+.swift in Sources */,
 				98003E0E293F20F6009FBC35 /* DarkModeManager.swift in Sources */,
 				66A8CF692937945300C17F84 /* UserDetailUseCase.swift in Sources */,
@@ -714,11 +721,12 @@
 				666E6F8E291CFADD00CECD4B /* MyPageViewController.swift in Sources */,
 				4F6F74B1292C9BF3007E7AC1 /* UserInfo.swift in Sources */,
 				98FDF8A5292F7A350083FA05 /* UIView+.swift in Sources */,
-				98FDF8A3292F5CCA0083FA05 /* MapKitViewController.swift in Sources */,
+				98FDF8A3292F5CCA0083FA05 /* MapViewController.swift in Sources */,
 				983AE9D6293514E8006547BD /* SettingsActionSheetCell.swift in Sources */,
 				4FA3242B2923646F00DB04D5 /* DiaryListItemEndpoint.swift in Sources */,
 				791837FF292225DC00BC6992 /* UIColor+.swift in Sources */,
 				4F307A4A293889C200FA36A0 /* SearchMusicUseCase.swift in Sources */,
+				98AE6A8A29445F2A0039A666 /* GetAddressUseCase.swift in Sources */,
 				666E6F7F291CF46800CECD4B /* AppCoordinator.swift in Sources */,
 				791529DC29332CF2005A8DDB /* ImageDTO.swift in Sources */,
 				9841D61B2926131200318EA9 /* LoginViewModel.swift in Sources */,

--- a/Segno/Segno/Data/Repository/LocationRepository.swift
+++ b/Segno/Segno/Data/Repository/LocationRepository.swift
@@ -13,6 +13,8 @@ import RxSwift
 protocol LocationRepository {
     var locationSubject: PublishSubject<Location> { get set }
     var addressSubject: PublishSubject<String> { get set }
+    func getAddress(by location: Location)
+    func getAddress(location: CLLocation)
     func getLocation()
     func stopLocation()
 }
@@ -46,6 +48,11 @@ final class LocationRepositoryImpl: NSObject, LocationRepository {
         }
     }
     
+    func getAddress(by location: Location) {
+        let cllocation = CLLocation(latitude: location.latitude, longitude: location.longitude)
+        getAddress(location: cllocation)
+    }
+    
     func getAddress(location: CLLocation) {
         let geocoder = CLGeocoder()
         let locale = Locale(identifier: "Ko-kr")
@@ -56,7 +63,7 @@ final class LocationRepositoryImpl: NSObject, LocationRepository {
             let fullAddress = address.description.components(separatedBy: ", ")[1]
             let array = Array(fullAddress.components(separatedBy: " ").dropFirst())
             let refinedAddress = array.joined(separator: " ")
-            debugPrint("full : ", refinedAddress)
+            debugPrint("변환된 주소값 : ", refinedAddress)
             
             self.addressSubject.onNext(refinedAddress)
         }

--- a/Segno/Segno/Domain/UseCase/GetAddressUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/GetAddressUseCase.swift
@@ -1,0 +1,36 @@
+//
+//  LocationUseCase.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/12/08.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol GetAddressUseCase {
+    var addressSubject: PublishSubject<String> { get set }
+    func getAddress(by location: Location)
+}
+
+final class GetAddressUseCaseImpl: GetAddressUseCase {
+    var addressSubject = PublishSubject<String>()
+    let repository: LocationRepository
+    private let disposeBag = DisposeBag()
+    
+    init(repository: LocationRepository = LocationRepositoryImpl()) {
+        self.repository = repository
+        bindAddressSubject()
+    }
+    
+    func getAddress(by location: Location) {
+        repository.getAddress(by: location)
+    }
+    
+    private func bindAddressSubject() {
+        repository.addressSubject
+            .bind(to: addressSubject)
+            .disposed(by: disposeBag)
+    }
+}

--- a/Segno/Segno/Domain/UseCase/LocationUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/LocationUseCase.swift
@@ -11,14 +11,12 @@ import RxSwift
 
 protocol LocationUseCase {
     var locationSubject: PublishSubject<Location> { get set }
-    var addressSubject: PublishSubject<String> { get set }
     func getLocation()
     func stopLocation()
 }
 
 final class LocationUseCaseImpl: LocationUseCase {
     var locationSubject = PublishSubject<Location>()
-    var addressSubject = PublishSubject<String>()
     let repository: LocationRepository
     private let disposeBag = DisposeBag()
     
@@ -36,10 +34,6 @@ final class LocationUseCaseImpl: LocationUseCase {
     }
     
     private func subscribeResults() {
-        repository.addressSubject
-            .bind(to: addressSubject)
-            .disposed(by: disposeBag)
-        
         repository.locationSubject
             .bind(to: locationSubject)
             .disposed(by: disposeBag)

--- a/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/DiaryCoordinator.swift
@@ -37,7 +37,7 @@ extension DiaryCoordinator: DiaryCollectionViewDelegate {
 
 extension DiaryCoordinator: DiaryDetailViewDelegate {
     func mapButtonTapped(viewController: UIViewController, location: Location) {
-        let mapKitViewController = MapKitViewController(location: location)
+        let mapKitViewController = MapViewController(viewModel: MapViewModel(), location: location)
         viewController.present(mapKitViewController, animated: true)
     }
 }

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -21,20 +21,21 @@ final class LocationContentView: UIView {
         static let fontSize: CGFloat = 16
         static let spacing: CGFloat = 10
         static let mapButtonSize: CGFloat = 30
+        static let titleText: String = "위치"
     }
     
-    private var location: CLLocation?
+    private var location: Location?
     private let disposeBag = DisposeBag()
     weak var delegate: LocationContentViewDelegate?
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .appFont(.surround, size: Metric.fontSize)
-        label.text = "위치"
+        label.text = Metric.titleText
         return label
     }()
     
-    private lazy var locationLabel: UILabel = {
+    lazy var locationLabel: UILabel = {
         let label = UILabel()
         label.font = .appFont(.surroundAir, size: Metric.fontSize)
         return label
@@ -46,9 +47,9 @@ final class LocationContentView: UIView {
         button.tintColor = .appColor(.black)
         button.rx.tap
             .bind { [weak self] in
-                // TODO: CLLocation 변수 location을 Location으로 변환하는 로직 필요. 지금은 임시 데이터 부여
-                let customLocation = Location(latitude: 37.248128, longitude: 127.076597)
-                self?.delegate?.mapButtonTapped(location: customLocation)
+                debugPrint("===>", self?.location)
+                guard let location = self?.location else { return }
+                self?.delegate?.mapButtonTapped(location: location)
             }
             .disposed(by: disposeBag)
         return button
@@ -87,9 +88,10 @@ final class LocationContentView: UIView {
         }
     }
     
-    func setLocation(location: CLLocation) {
-        // TODO: titleLabel에 표시하기 위해 CLLocation을 주소 String으로 변환하는 로직 필요
-        
+    func setLocation(cllocation: CLLocation) {
+        let latitude = cllocation.coordinate.latitude
+        let longitude = cllocation.coordinate.longitude
+        let location = Location(latitude: latitude, longitude: longitude)
         self.location = location
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -123,6 +123,11 @@ final class DiaryDetailViewController: UIViewController {
         
 //        viewModel.testDataInsert() // 임시 투입 메서드입니다.
     }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        bindAddress()
+    }
     
     override func viewWillDisappear(_ animated: Bool) {
         viewModel.stopMusic()
@@ -234,13 +239,34 @@ final class DiaryDetailViewController: UIViewController {
             .map { $0.createCLLocation() }
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] location in
-                self?.locationContentView.setLocation(location: location)
+                self?.locationContentView.setLocation(cllocation: location)
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.addressSubject
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] address in
+                self?.locationContentView.locationLabel.text  = address
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindAddress() {
+        viewModel.locationObservable
+            .compactMap { $0 }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] location in
+                self?.getAddress(by: location)
             })
             .disposed(by: disposeBag)
     }
     
     private func getDiary() {
         viewModel.getDiary()
+    }
+    
+    private func getAddress(by location: Location) {
+        viewModel.getAddress(by: location)
     }
 }
 

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -42,6 +42,7 @@ final class DiaryDetailViewModel {
         
         debugPrint(itemIdentifier)
         setupMusicPlayer()
+        bindAddress()
     }
     
     func testDataInsert() {
@@ -81,5 +82,11 @@ final class DiaryDetailViewModel {
     
     func getAddress(by location: Location) {
         getAddressUseCase.getAddress(by: location)
+    }
+    
+    func bindAddress() {
+        getAddressUseCase.addressSubject
+            .bind(to: addressSubject)
+            .disposed(by: disposeBag)
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -14,7 +14,10 @@ final class DiaryDetailViewModel {
     private let itemIdentifier: String
     let getDetailUseCase: DiaryDetailUseCase
     let playMusicUseCase: PlayMusicUseCase
+    let getAddressUseCase: GetAddressUseCase
+    
     var diaryItem = PublishSubject<DiaryDetail>()
+    var addressSubject = PublishSubject<String>()
     var isPlaying = BehaviorSubject(value: false)
     // TODO: DiaryDetail에 date 추가
     // lazy var dateObservable = diaryItem.map { $0.date }
@@ -29,12 +32,15 @@ final class DiaryDetailViewModel {
     
     init(itemIdentifier: String,
          getDetailUseCase: DiaryDetailUseCase = DiaryDetailUseCaseImpl(),
-         playMusicUseCase: PlayMusicUseCase = PlayMusicUseCaseImpl()) {
+         playMusicUseCase: PlayMusicUseCase = PlayMusicUseCaseImpl(),
+         getAddressUseCase: GetAddressUseCase = GetAddressUseCaseImpl()
+    ) {
         self.itemIdentifier = itemIdentifier
         self.getDetailUseCase = getDetailUseCase
         self.playMusicUseCase = playMusicUseCase
+        self.getAddressUseCase = getAddressUseCase
         
-        print(itemIdentifier)
+        debugPrint(itemIdentifier)
         setupMusicPlayer()
     }
     
@@ -71,5 +77,9 @@ final class DiaryDetailViewModel {
     func stopMusic() {
         isPlaying.onNext(false)
         playMusicUseCase.stopPlaying()
+    }
+    
+    func getAddress(by location: Location) {
+        getAddressUseCase.getAddress(by: location)
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/DiaryEditViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryEditViewModel.swift
@@ -21,6 +21,7 @@ final class DiaryEditViewModel {
     let diaryDetailUseCase: DiaryDetailUseCase
     let searchMusicUseCase: SearchMusicUseCase
     let locationUseCase: LocationUseCase
+    let getAddressUseCase: GetAddressUseCase
     let imageUseCase: ImageUseCase
     let localUtilityRepository: LocalUtilityRepository
     
@@ -33,12 +34,14 @@ final class DiaryEditViewModel {
          diaryDetailUseCase: DiaryDetailUseCase = DiaryDetailUseCaseImpl(),
          searchMusicUseCase: SearchMusicUseCase = SearchMusicUseCaseImpl(),
          locationUseCase: LocationUseCase = LocationUseCaseImpl(),
+         getAddressUseCase: GetAddressUseCase = GetAddressUseCaseImpl(),
          imageUseCase: ImageUseCase = ImageUseCaseImpl(),
          localUtilityRepository: LocalUtilityRepository = LocalUtilityRepositoryImpl()) {
         self.diaryEditUseCase = diaryEditUseCase
         self.diaryDetailUseCase = diaryDetailUseCase
         self.searchMusicUseCase = searchMusicUseCase
         self.locationUseCase = locationUseCase
+        self.getAddressUseCase = getAddressUseCase
         self.imageUseCase = imageUseCase
         self.localUtilityRepository = localUtilityRepository
         subscribeSearchingStatus()
@@ -91,7 +94,7 @@ final class DiaryEditViewModel {
             .bind(to: locationSubject)
             .disposed(by: disposeBag)
         
-        locationUseCase.addressSubject
+        getAddressUseCase.addressSubject
             .bind(to: addressSubject)
             .disposed(by: disposeBag)
     }

--- a/Segno/Segno/Presentation/ViewModel/MapViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/MapViewModel.swift
@@ -25,4 +25,8 @@ final class MapViewModel {
             .disposed(by: disposeBag)
             
     }
+    
+    func getAddress(by location: Location) {
+        getAddressUseCase.getAddress(by: location)
+    }
 }

--- a/Segno/Segno/Presentation/ViewModel/MapViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/MapViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  MapViewModel.swift
+//  Segno
+//
+//  Created by YOONJONG on 2022/12/10.
+//
+
+import RxSwift
+
+final class MapViewModel {
+    private let getAddressUseCase: GetAddressUseCase
+    private let disposeBag = DisposeBag()
+    
+    var addressSubject = PublishSubject<String>()
+    
+    init(getAddressUseCase: GetAddressUseCase = GetAddressUseCaseImpl()) {
+        self.getAddressUseCase = getAddressUseCase
+        
+        bind()
+    }
+    
+    private func bind() {
+        getAddressUseCase.addressSubject
+            .bind(to: addressSubject)
+            .disposed(by: disposeBag)
+            
+    }
+}


### PR DESCRIPTION
12/10 #196 #197 #198 #199 #200 #201

## 작업한 내용
### LocationUseCase에서 주소를 요청하는 로직을 분리하여 GetAddressUseCase 를 생성했습니다.
- 이제 LocationUseCase는 Location을 바인드하며 위치을 받아오거나 멈추도록 요청하는 역할만 수행합니다.
### LocationView의 더미 데이터를 실제 Location 데이터로 수정합니다.
- 지금은 서버 이슈로 위치를 확인할 수 없습니다.
### 전체적인 위치 관련 로직을 수정했습니다.

## 고민한 점 및 어려웠던 점
### 위치 관련 UseCase를 사용하는 곳이 3군데라 이를 어떻게 사용해야 할까에 대한 고민이 많았습니다.
- 일단 UseCase를 분리했습니다. UseCase를 분리하니 로직이 보다 명료해졌습니다.
