### PR TITLE
DiaryEditViewController - imagePicker에 카메라 옵션 추가

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -880,6 +880,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "";
+				INFOPLIST_KEY_NSCameraUsageDescription = "";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 받아오기 위해 권한이 필요합니다.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음악 검색 기능을 위해 마이크 사용 허가가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -912,6 +913,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Segno/Resource/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "";
+				INFOPLIST_KEY_NSCameraUsageDescription = "";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 정보를 받아오기 위해 권한이 필요합니다.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음악 검색 기능을 위해 마이크 사용 허가가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -30,6 +30,11 @@ final class DiaryEditViewController: UIViewController {
         static let textFieldFontSize: CGFloat = 12
         static let padding: CGFloat = 12
         static let titlePlaceholder = "제목을 입력하세요."
+        static let pickerActionSheetTitle = "옵션 선택"
+        static let pickerActionSheetMessage = "원하는 옵션을 선택하세요."
+        static let libaryText = "앨범"
+        static let cameraText = "카메라"
+        static let cancelText = "취소"
         static let bodyPlaceholder = "내용을 입력하세요."
         static let musicPlaceholder = "지금 이 음악은 뭘까요?"
         static let searching = "검색 중입니다..."
@@ -328,13 +333,29 @@ final class DiaryEditViewController: UIViewController {
         photoImageViewTapGesture.rx.event
             .bind(onNext: { recognizer in
                 self.view.endEditing(true)
-                self.present(self.imagePicker, animated: true)
+                self.presentPickerActionSheet()
             })
             .disposed(by: disposeBag)
     }
     
+    private func presentPickerActionSheet() {
+        let alert = UIAlertController(title: Metric.pickerActionSheetTitle, message: Metric.pickerActionSheetMessage, preferredStyle: .actionSheet)
+        let libraryAction = UIAlertAction(title: Metric.libaryText, style: .default) { _ in
+            self.imagePicker.sourceType = .photoLibrary
+            self.present(self.imagePicker, animated: true)
+        }
+        let cameraAction = UIAlertAction(title: Metric.cameraText, style: .default) { _ in
+            self.imagePicker.sourceType = .camera
+            self.present(self.imagePicker, animated: true)
+        }
+        let cancelAction = UIAlertAction(title: Metric.cancelText, style: .cancel)
+        alert.addAction(libraryAction)
+        alert.addAction(cameraAction)
+        alert.addAction(cancelAction)
+        present(alert, animated: true, completion: nil)
+    }
+    
     private func setImagePicker() {
-        imagePicker.sourceType = .photoLibrary
         imagePicker.allowsEditing = true
         imagePicker.delegate = self
     }


### PR DESCRIPTION
12/10 #85 

## 작업한 내용
### DiaryEditViewController의 이미지뷰 탭할 시 앨범에서 사진 선택 뿐이 아닌 카메라 옵션을 추가했습니다.

## 고민한 점 및 어려웠던 점
### 역시나 익스텐션 분리가 필요해보입니다만..
- 어차피 클로저로 액션을 넘겨줘야 하기 때문에 코드 양적인 층면을 봤을 때는 얼마나 효용이 있을지 모르겠습니다.
