### PR TITLE
음악 세션 Subject 제거 및 자동재생 구현

### DIFF
--- a/Segno/Segno/Data/Repository/MusicRepository.swift
+++ b/Segno/Segno/Data/Repository/MusicRepository.swift
@@ -14,6 +14,8 @@ protocol MusicRepository {
     func toggleMusicPlayer()
     func stopPlayingMusic()
     func subscribeSearchresult() -> Observable<ShazamSearchResult>
+    func subscribePlayingStatus() -> Observable<Bool>
+    func subscribePlayerError() -> Observable<MusicError>
 }
 
 final class MusicRepositoryImpl: MusicRepository {
@@ -49,5 +51,13 @@ final class MusicRepositoryImpl: MusicRepository {
     
     func subscribeSearchresult() -> Observable<ShazamSearchResult> {
         return shazamSession.resultObservable
+    }
+    
+    func subscribePlayingStatus() -> Observable<Bool> {
+        return musicSession.playingStatusObservable
+    }
+    
+    func subscribePlayerError() -> Observable<MusicError> {
+        return musicSession.errorStatusObservable
     }
 }

--- a/Segno/Segno/Data/Repository/MusicRepository.swift
+++ b/Segno/Segno/Data/Repository/MusicRepository.swift
@@ -15,6 +15,7 @@ protocol MusicRepository {
     func stopPlayingMusic()
     func subscribeSearchresult() -> Observable<ShazamSearchResult>
     func subscribePlayingStatus() -> Observable<Bool>
+    func subscribeDownloadStatus() -> Observable<Bool>
     func subscribePlayerError() -> Observable<MusicError>
 }
 
@@ -55,6 +56,10 @@ final class MusicRepositoryImpl: MusicRepository {
     
     func subscribePlayingStatus() -> Observable<Bool> {
         return musicSession.playingStatusObservable
+    }
+    
+    func subscribeDownloadStatus() -> Observable<Bool> {
+        return musicSession.downloadStatusObservable
     }
     
     func subscribePlayerError() -> Observable<MusicError> {

--- a/Segno/Segno/Data/Session/MusicSession.swift
+++ b/Segno/Segno/Data/Session/MusicSession.swift
@@ -17,10 +17,14 @@ final class MusicSession {
         return playerState.playbackStatus == .playing
     }
     private var playingStatus = BehaviorSubject(value: false)
+    private var isReady = BehaviorSubject(value: false)
     private var errorStatus = PublishSubject<MusicError>()
     
     var playingStatusObservable: Observable<Bool> {
         return playingStatus.asObservable()
+    }
+    var downloadStatusObservable: Observable<Bool> {
+        return isReady.asObservable()
     }
     var errorStatusObservable: Observable<MusicError> {
         return errorStatus.asObservable()
@@ -42,6 +46,7 @@ final class MusicSession {
                     let response = try await request.response()
                     if let item = response.items.first {
                         player.queue = [item]
+                        isReady.onNext(true)
                     }
                 } catch {
                     handleMusicError(.failedToFetch)

--- a/Segno/Segno/Data/Session/MusicSession.swift
+++ b/Segno/Segno/Data/Session/MusicSession.swift
@@ -20,7 +20,6 @@ final class MusicSession {
     private var errorStatus = PublishSubject<MusicError>()
     
     var playingStatusObservable: Observable<Bool> {
-        debugPrint("Changed to \(try? playingStatus.value())")
         return playingStatus.asObservable()
     }
     var errorStatusObservable: Observable<MusicError> {
@@ -45,10 +44,10 @@ final class MusicSession {
                         player.queue = [item]
                     }
                 } catch {
-                    debugPrint(MusicError.failedToFetch)
+                    handleMusicError(.failedToFetch)
                 }
             default:
-                debugPrint(MusicError.libraryAccessDenied)
+                handleMusicError(.libraryAccessDenied)
             }
         }
     }
@@ -59,7 +58,7 @@ final class MusicSession {
             playMusic()
         } else {
             player.pause()
-            playingStatus.onNext(isPlaying)
+            playingStatus.onNext(false)
         }
     }
     
@@ -67,9 +66,9 @@ final class MusicSession {
         Task {
             do {
                 try await player.play()
-                playingStatus.onNext(isPlaying)
+                playingStatus.onNext(true)
             } catch {
-                debugPrint(MusicError.failedToPlay)
+                handleMusicError(.failedToPlay)
             }
         }
     }
@@ -77,6 +76,11 @@ final class MusicSession {
     func stopMusic() {
         player.stop()
         player.queue = []
-        playingStatus.onNext(isPlaying)
+        playingStatus.onNext(false)
+    }
+    
+    private func handleMusicError(_ error: MusicError) {
+        errorStatus.onNext(error)
+        playingStatus.onNext(false)
     }
 }

--- a/Segno/Segno/Data/Session/MusicSession.swift
+++ b/Segno/Segno/Data/Session/MusicSession.swift
@@ -16,12 +16,11 @@ final class MusicSession {
     private var isPlaying: Bool {
         return playerState.playbackStatus == .playing
     }
-    private var playingStatus: BehaviorSubject<Bool> {
-        return BehaviorSubject(value: isPlaying)
-    }
+    private var playingStatus = BehaviorSubject(value: false)
     private var errorStatus = PublishSubject<MusicError>()
     
     var playingStatusObservable: Observable<Bool> {
+        debugPrint("Changed to \(try? playingStatus.value())")
         return playingStatus.asObservable()
     }
     var errorStatusObservable: Observable<MusicError> {
@@ -60,6 +59,7 @@ final class MusicSession {
             playMusic()
         } else {
             player.pause()
+            playingStatus.onNext(isPlaying)
         }
     }
     
@@ -67,6 +67,7 @@ final class MusicSession {
         Task {
             do {
                 try await player.play()
+                playingStatus.onNext(isPlaying)
             } catch {
                 debugPrint(MusicError.failedToPlay)
             }
@@ -76,5 +77,6 @@ final class MusicSession {
     func stopMusic() {
         player.stop()
         player.queue = []
+        playingStatus.onNext(isPlaying)
     }
 }

--- a/Segno/Segno/Data/Session/MusicSession.swift
+++ b/Segno/Segno/Data/Session/MusicSession.swift
@@ -7,12 +7,25 @@
 
 import MusicKit
 
+import RxSwift
+
 final class MusicSession {
     private lazy var player = ApplicationMusicPlayer.shared
     private lazy var playerState = player.state
     
     private var isPlaying: Bool {
         return playerState.playbackStatus == .playing
+    }
+    private var playingStatus: BehaviorSubject<Bool> {
+        return BehaviorSubject(value: isPlaying)
+    }
+    private var errorStatus = PublishSubject<MusicError>()
+    
+    var playingStatusObservable: Observable<Bool> {
+        return playingStatus.asObservable()
+    }
+    var errorStatusObservable: Observable<MusicError> {
+        return errorStatus.asObservable()
     }
     
     init() {

--- a/Segno/Segno/Domain/UseCase/PlayMusicUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/PlayMusicUseCase.swift
@@ -7,10 +7,14 @@
 
 import Foundation
 
+import RxSwift
+
 protocol PlayMusicUseCase {
     func setupPlayer(_ song: MusicInfo?)
     func togglePlayer()
     func stopPlaying()
+    func subscribePlayingStatus() -> Observable<Bool>
+    func subscribePlayerError() -> Observable<MusicError>
 }
 
 final class PlayMusicUseCaseImpl: PlayMusicUseCase {
@@ -30,5 +34,13 @@ final class PlayMusicUseCaseImpl: PlayMusicUseCase {
     
     func stopPlaying() {
         musicRepository.stopPlayingMusic()
+    }
+    
+    func subscribePlayingStatus() -> Observable<Bool> {
+        return musicRepository.subscribePlayingStatus()
+    }
+    
+    func subscribePlayerError() -> Observable<MusicError> {
+        return musicRepository.subscribePlayerError()
     }
 }

--- a/Segno/Segno/Domain/UseCase/PlayMusicUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/PlayMusicUseCase.swift
@@ -14,6 +14,7 @@ protocol PlayMusicUseCase {
     func togglePlayer()
     func stopPlaying()
     func subscribePlayingStatus() -> Observable<Bool>
+    func subscribeDownloadStatus() -> Observable<Bool>
     func subscribePlayerError() -> Observable<MusicError>
 }
 
@@ -38,6 +39,10 @@ final class PlayMusicUseCaseImpl: PlayMusicUseCase {
     
     func subscribePlayingStatus() -> Observable<Bool> {
         return musicRepository.subscribePlayingStatus()
+    }
+    
+    func subscribeDownloadStatus() -> Observable<Bool> {
+        return musicRepository.subscribeDownloadStatus()
     }
     
     func subscribePlayerError() -> Observable<MusicError> {

--- a/Segno/Segno/Entity/DiaryDetail.swift
+++ b/Segno/Segno/Entity/DiaryDetail.swift
@@ -57,6 +57,6 @@ struct DiaryDetail: Encodable {
 
 #if DEBUG
 extension DiaryDetail {
-    static let dummy = DiaryDetail(identifier: "1", title: "테스트", tags: ["테스트"], imagePath: "", bodyText: "테스트", musicInfo: MusicInfo.yokohama, location: nil)
+    static let dummy = DiaryDetail(identifier: "1", title: "테스트", tags: ["큿소"], imagePath: "", bodyText: "테스트", musicInfo: MusicInfo.yokohama, location: nil)
 }
 #endif

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -104,6 +104,10 @@ final class MusicContentView: UIView {
         albumArtImageView.kf.setImage(with: info.imageURL)
     }
     
+    func activatePlayButton(isReady status: Bool) {
+        playButton.isEnabled = status
+    }
+    
     func changeButtonIcon(isPlaying status: Bool) {
         switch status {
         case true:

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -120,7 +120,7 @@ final class DiaryDetailViewController: UIViewController {
         setupLayout()
         bindDiaryItem()
         getDiary()
-        viewModel.testDataInsert() // 임시 투입 메서드입니다.
+//        viewModel.testDataInsert() // 임시 투입 메서드입니다.
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -237,6 +237,13 @@ final class DiaryDetailViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] status in
                 self?.musicContentView.changeButtonIcon(isPlaying: status)
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.isReady
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] status in
+                self?.musicContentView.activatePlayButton(isReady: status)
             })
             .disposed(by: disposeBag)
         

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -120,8 +120,7 @@ final class DiaryDetailViewController: UIViewController {
         setupLayout()
         bindDiaryItem()
         getDiary()
-        
-//        viewModel.testDataInsert() // 임시 투입 메서드입니다.
+        viewModel.testDataInsert() // 임시 투입 메서드입니다.
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -194,7 +193,6 @@ final class DiaryDetailViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] tags in
                 tags.forEach { tagTitle in
-                    debugPrint(tagTitle)
                     let tagView = TagView(tagTitle: tagTitle)
                     self?.tagStackView.addArrangedSubview(tagView)
                 }
@@ -222,6 +220,19 @@ final class DiaryDetailViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        viewModel.locationObservable
+            .compactMap { $0 }
+            .map { $0.createCLLocation() }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] location in
+                self?.locationContentView.setLocation(location: location)
+            })
+            .disposed(by: disposeBag)
+        
+        subscribeMusicPlayer()
+    }
+    
+    private func subscribeMusicPlayer() {
         viewModel.isPlaying
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] status in
@@ -229,12 +240,10 @@ final class DiaryDetailViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        viewModel.locationObservable
-            .compactMap { $0 }
-            .map { $0.createCLLocation() }
+        viewModel.playerErrorStatus
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] location in
-                self?.locationContentView.setLocation(location: location)
+            .subscribe(onNext: { [weak self] error in
+                self?.makeOKAlert(title: "Error!", message: error.localizedDescription)
             })
             .disposed(by: disposeBag)
     }

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -14,6 +14,7 @@ final class DiaryDetailViewModel {
     private let itemIdentifier: String
     let getDetailUseCase: DiaryDetailUseCase
     let playMusicUseCase: PlayMusicUseCase
+    let settingsUseCase: SettingsUseCase
     
     var diaryItem = PublishSubject<DiaryDetail>()
     var isPlaying = BehaviorSubject(value: false)
@@ -32,15 +33,17 @@ final class DiaryDetailViewModel {
     
     init(itemIdentifier: String,
          getDetailUseCase: DiaryDetailUseCase = DiaryDetailUseCaseImpl(),
-         playMusicUseCase: PlayMusicUseCase = PlayMusicUseCaseImpl()) {
+         playMusicUseCase: PlayMusicUseCase = PlayMusicUseCaseImpl(),
+         settingsUseCase: SettingsUseCase = SettingsUseCaseImpl()) {
         self.itemIdentifier = itemIdentifier
         self.getDetailUseCase = getDetailUseCase
         self.playMusicUseCase = playMusicUseCase
+        self.settingsUseCase = settingsUseCase
         
-        print(itemIdentifier)
         subscribePlayingStatus()
         subscribePlayerError()
         setupMusicPlayer()
+        // 오토플레이 메서드를 잠시 후에 실행 (혹은 다운로드가 끝나면 실행)
     }
     
     func testDataInsert() {
@@ -86,5 +89,16 @@ final class DiaryDetailViewModel {
                 self?.playerErrorStatus.onNext(error)
             })
             .disposed(by: disposeBag)
+    }
+    
+    func autoPlay() {
+        switch settingsUseCase.getAutoPlayMode() {
+        case true:
+            debugPrint(true)
+            toggleMusicPlayer()
+        case false:
+            debugPrint(false)
+            return
+        }
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -75,7 +75,6 @@ final class DiaryDetailViewModel {
     func subscribePlayingStatus() {
         playMusicUseCase.subscribePlayingStatus()
             .subscribe(onNext: { [weak self] status in
-                debugPrint("isPlaying: \(self?.isPlaying)")
                 self?.isPlaying.onNext(status)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
12/11 #92 

## 작업한 내용
### MusicSession의 결과값 구독을 위해 설정해 두었던 PublishSubject를 삭제했습니다.
- 별도의 Observable을 두고 실행됩니다.
- 재생 실패의 경우, 오류에 대한 간단한 설명이 팝업으로 표시됩니다.
### 자동 재생 기능을 구현했습니다.
- 해당 음원이 다운로드가 완료된 후 바로 재생됩니다.

## 고민한 점 및 어려웠던 점
### 어느 시점에 자동재생을 시작하게 해야 할 지 고민했습니다.
- 뷰 모델의 이니셜라이즈 시점에 자동재생 설정을 체크하고 자동재생을 수행하면, 음원 데이터의 다운로드가 완료되지 않은 상태에서 재생을 시도하려 하는 것이기 때문에 에러가 발생했습니다.
- 콘솔에 출력되는 로그를 토대로, 애플 서버와의 통신이 직접 일어남을 유추할 수 있었습니다.
- 그래서, 음악 데이터를 가져오는 데 성공했을 때 어떤 처리를 해 주었었는지 주목하고, 해당 부분에 음악 플레이어가 준비가 되었다는 것을 나타내는 프로퍼티를 전달해 주고, 해당 프로퍼티를 옵저빙함으로써 자동재생이 알맞는 타이밍에 되도록 조정했습니다.