### PR TITLE
로그아웃 후 로그인 화면으로 이동

### DIFF
--- a/Segno/Segno/Application/AppCoordinator.swift
+++ b/Segno/Segno/Application/AppCoordinator.swift
@@ -35,6 +35,7 @@ final class AppCoordinator: Coordinator {
     
     func startTabBarCoordinator() {
         let tabBarCoordinator = TabBarCoordinator(navigationController)
+        tabBarCoordinator.delegate = self
         tabBarCoordinator.start()
         childCoordinators.append(tabBarCoordinator)
     }
@@ -45,5 +46,13 @@ extension AppCoordinator: LoginCoordinatorDelegate {
         childCoordinators = childCoordinators.filter { $0 === coordinator }
         
         startTabBarCoordinator()
+    }
+}
+
+extension AppCoordinator: TabBarCoordinatorDelegate {
+    func logoutButtonTapped() {
+        navigationController.popViewController(animated: true)
+        
+        startLoginCoordinator()
     }
 }

--- a/Segno/Segno/Presentation/Coordinator/LoginCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/LoginCoordinator.swift
@@ -24,7 +24,7 @@ final class LoginCoordinator: Coordinator {
     func start() {
         let vc = LoginViewController()
         vc.delegate = self
-        self.navigationController.pushViewController(vc, animated: true)
+        self.navigationController.pushViewController(vc, animated: false)
     }
 }
 

--- a/Segno/Segno/Presentation/Coordinator/MyPageCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/MyPageCoordinator.swift
@@ -7,9 +7,14 @@
 
 import UIKit
 
+protocol MyPageCoordinatorDelegate: AnyObject {
+    func logoutButtonTapped()
+}
+
 final class MyPageCoordinator: Coordinator {
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
+    weak var delegate: MyPageCoordinatorDelegate?
     
     init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -26,5 +31,9 @@ extension MyPageCoordinator: MyPageViewDelegate {
     func settingButtonTapped() {
         let vc = SettingsViewController()
         navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func logoutButtonTapped() {
+        delegate?.logoutButtonTapped()
     }
 }

--- a/Segno/Segno/Presentation/Coordinator/TabBar/TabBarCoordinator.swift
+++ b/Segno/Segno/Presentation/Coordinator/TabBar/TabBarCoordinator.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol TabBarCoordinatorDelegate: AnyObject {
+    func logoutButtonTapped()
+}
+
 final class TabBarCoordinator: Coordinator {
     private enum Metric {
         static let tabBarItemFontSize: CGFloat = 15
@@ -15,6 +19,7 @@ final class TabBarCoordinator: Coordinator {
     var navigationController: UINavigationController
     var tabBarController: UITabBarController
     var childCoordinators: [Coordinator] = []
+    weak var delegate: TabBarCoordinatorDelegate?
     
     init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -34,7 +39,7 @@ private extension TabBarCoordinator {
     private func configureTabBarController(with tabViewControllers: [UIViewController]) {
         self.tabBarController.setViewControllers(tabViewControllers, animated: true)
         self.tabBarController.selectedIndex = TabBarPageCase.diary.pageOrderNumber
-        self.navigationController.pushViewController(tabBarController, animated: true)
+        self.navigationController.pushViewController(tabBarController, animated: false)
     }
     
     func createTabNavigationController(page: TabBarPageCase) -> UINavigationController {
@@ -73,7 +78,14 @@ private extension TabBarCoordinator {
     
     func connectMyPageFlow(to tabNavigationController: UINavigationController) {
         let myPageCoordinator = MyPageCoordinator(tabNavigationController)
+        myPageCoordinator.delegate = self
         myPageCoordinator.start()
         childCoordinators.append(myPageCoordinator)
+    }
+}
+
+extension TabBarCoordinator: MyPageCoordinatorDelegate {
+    func logoutButtonTapped() {
+        delegate?.logoutButtonTapped()
     }
 }

--- a/Segno/Segno/Presentation/ViewController/LoginViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/LoginViewController.swift
@@ -167,10 +167,8 @@ final class LoginViewController: UIViewController {
                 DispatchQueue.main.async {
                     switch result {
                     case true:
-                        self?.titleLabel.backgroundColor = .blue // 테스트용 색상
                         self?.delegate?.loginDidSucceed()
                     case false:
-                        self?.titleLabel.backgroundColor = .orange // 테스트용 색상
                         self?.delegate?.loginDidFail()
                     }
                 }

--- a/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
@@ -29,6 +29,7 @@ enum MyPageCellModel {
 
 protocol MyPageViewDelegate: AnyObject {
     func settingButtonTapped()
+    func logoutButtonTapped()
 }
 
 final class MyPageViewController: UIViewController {
@@ -122,7 +123,7 @@ final class MyPageViewController: UIViewController {
                 numberFormatter.numberStyle = .decimal
                 
                 let price = Double(writtenDiary)
-                let result = numberFormatter.string(from: NSNumber(value:price)) ?? "0" + "개"
+                let result = (numberFormatter.string(from: NSNumber(value:price)) ?? "0") + "개"
                 
                 _ = Observable<[MyPageCellModel]>.just([
                     .writtenDiary(title: "작성한 일기 수", subtitle: result),
@@ -145,6 +146,7 @@ final class MyPageViewController: UIViewController {
                             return cell
                         }
                     }
+                    .disposed(by: self?.disposeBag ?? DisposeBag())
             })
             .disposed(by: disposeBag)
         
@@ -173,8 +175,9 @@ final class MyPageViewController: UIViewController {
     }
     
     private func logoutButtonTapped() {
-        localUtilityRepository.deleteToken()
-        // TODO: 로그아웃 후에 로그인코디네이터 띄워주기
+        _ = localUtilityRepository.deleteToken()
+        
+        mypageDelegate?.logoutButtonTapped()
     }
 }
 


### PR DESCRIPTION
12/11

## 작업한 내용
### 로그아웃 후 로그인 페이지로 이동
- 특별히 로그아웃 후 재로그인하면 기존 코드상 pushViewContoller()에서 animated가 true로 발동하여 지저분하였습니다.
- 따라서 몇몇 부분에서 false로 바꿔주었습니다.

## 고민한 점 및 어려웠던 점
### 로그아웃 전에 설정 페이지에 접속 후, 로그아웃 후 재로그인 하면 Assertion failed 오류가 떴습니다.
> Assertion failed: Delegate was changed from time it was first set.
- 이에 설정 탭을 세팅할 때 사용한 Observable을 dispose 시키지 않아서 발생했음을 확인하여 수정하였습니다.
