### PR TITLE
위치 관련 이슈 수정

### DIFF
--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -56,7 +56,6 @@ final class DiaryEditViewController: UIViewController {
     private var disposeBag = DisposeBag()
     private var tags: [String] = []
     private var location: Location?
-    private var address = Metric.locationPlaceholder
     
     private lazy var mainScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -527,9 +526,7 @@ extension DiaryEditViewController {
                     self.locationInfoLabel.text = Metric.searching
                     self.addlocationButton.tintColor = .systemRed
                 case false:
-                    self.locationInfoLabel.text = self.address
                     self.addlocationButton.tintColor = .appColor(.white)
-                    
                 }
             })
             .disposed(by: disposeBag)
@@ -548,15 +545,15 @@ extension DiaryEditViewController {
 }
 extension DiaryEditViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        var newImage: UIImage? = nil // update 할 이미지
+        var newImage: UIImage? = nil
         
         if let possibleImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
-            newImage = possibleImage // 수정된 이미지가 있을 경우
+            newImage = possibleImage
         } else if let possibleImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            newImage = possibleImage // 원본 이미지가 있을 경우
+            newImage = possibleImage
         }
         photoImageView.backgroundColor = .clear
-        photoImageView.image = newImage // 받아온 이미지를 update
+        photoImageView.image = newImage
         dismiss(animated: true)
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -237,6 +237,7 @@ final class DiaryEditViewController: UIViewController {
         
         tabBarController?.tabBar.isHidden = false
         removeRegisterForKeyboardNotification()
+        viewModel.stopLocation()
     }
     
     private func setupView() {

--- a/Segno/Segno/Presentation/ViewModel/DiaryEditViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryEditViewModel.swift
@@ -86,12 +86,15 @@ final class DiaryEditViewModel {
         isReceivingLocation
             .withUnretained(self)
             .subscribe(onNext: {
-                $1 ? self.locationUseCase.getLocation() : self.locationUseCase.stopLocation()
+                $1 ? self.getLocation() : self.stopLocation()
             })
             .disposed(by: disposeBag)
         
         locationUseCase.locationSubject
-            .bind(to: locationSubject)
+            .subscribe(onNext: { [weak self] location in
+                self?.locationSubject.onNext(location)
+                self?.getAddressUseCase.getAddress(by: location)
+            })
             .disposed(by: disposeBag)
         
         getAddressUseCase.addressSubject
@@ -148,5 +151,13 @@ final class DiaryEditViewModel {
                 self?.isSucceed.onNext(false)
             })
             .disposed(by: disposeBag)
+    }
+    
+    func getLocation() {
+        locationUseCase.getLocation()
+    }
+    
+    func stopLocation() {
+        locationUseCase.stopLocation()
     }
 }


### PR DESCRIPTION
12/12

## 작업한 내용
### 위치 추적 버튼을 눌렀을 때 LocationInfoLabel이 업데이트 되지 않는 문제를 수정했습니다.
- 위치 추적 버튼을 눌러 ViewModel단에서 위치(Location)을 받아오기만 하고 getAddressUseCase(by: Location) 메서드를 실행시키지 않았던 탓이었습니다.
### DiaryEditVC에서 나가면 위치 추적을 멈추도록 수정했습니다.
- 이를 위해 ViewModel단에서 유즈케이스에서 위치를 불러오고 멈추는 부분을 getLocation / stopLocation 메서드로 분리했습니다.
