### PR TITLE
UI 관련 편의 기능 수정

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		4FA324262923600C00DB04D5 /* DiaryListDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA324252923600C00DB04D5 /* DiaryListDTO.swift */; };
 		4FA32428292363AB00DB04D5 /* DiaryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA32427292363AA00DB04D5 /* DiaryRepository.swift */; };
 		4FA3242B2923646F00DB04D5 /* DiaryListItemEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA3242A2923646F00DB04D5 /* DiaryListItemEndpoint.swift */; };
+		4FBB42192946333A0017DAB8 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBB42182946333A0017DAB8 /* UIImageView+.swift */; };
 		4FCAC5C2292B5C9000BF9CDD /* LoginSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCAC5C1292B5C9000BF9CDD /* LoginSession.swift */; };
 		4FEBFAAB291CF30E00E78139 /* DiaryListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */; };
 		4FEBFAAD291CF62E00E78139 /* DiaryDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */; };
@@ -148,6 +149,7 @@
 		4FA324252923600C00DB04D5 /* DiaryListDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListDTO.swift; sourceTree = "<group>"; };
 		4FA32427292363AA00DB04D5 /* DiaryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryRepository.swift; sourceTree = "<group>"; };
 		4FA3242A2923646F00DB04D5 /* DiaryListItemEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListItemEndpoint.swift; sourceTree = "<group>"; };
+		4FBB42182946333A0017DAB8 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		4FCAC5C1292B5C9000BF9CDD /* LoginSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSession.swift; sourceTree = "<group>"; };
 		4FEBFAAA291CF30E00E78139 /* DiaryListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListItem.swift; sourceTree = "<group>"; };
 		4FEBFAAC291CF62E00E78139 /* DiaryDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDetail.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 				4FEBFAB0291CFB5500E78139 /* SHMediaItem+.swift */,
 				7918380729233F7100BC6992 /* UIButton+.swift */,
 				4F51A6FE2940FE810039D86A /* UIViewController+.swift */,
+				4FBB42182946333A0017DAB8 /* UIImageView+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -720,6 +723,7 @@
 				4F589DD9293FBA0900DB39E5 /* ShazamError.swift in Sources */,
 				666E6F8E291CFADD00CECD4B /* MyPageViewController.swift in Sources */,
 				4F6F74B1292C9BF3007E7AC1 /* UserInfo.swift in Sources */,
+				4FBB42192946333A0017DAB8 /* UIImageView+.swift in Sources */,
 				98FDF8A5292F7A350083FA05 /* UIView+.swift in Sources */,
 				98FDF8A3292F5CCA0083FA05 /* MapViewController.swift in Sources */,
 				983AE9D6293514E8006547BD /* SettingsActionSheetCell.swift in Sources */,

--- a/Segno/Segno/Extension/UIImageView+.swift
+++ b/Segno/Segno/Extension/UIImageView+.swift
@@ -1,0 +1,22 @@
+//
+//  UIImageView+.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2022/12/12.
+//
+
+import UIKit
+
+import Kingfisher
+
+extension UIImageView {
+    func setImage(from imagePath: String) {
+        guard let imageURL = BaseURL.getImageURL(imagePath: imagePath) else { return }
+        let resource = ImageResource(downloadURL: imageURL, cacheKey: imagePath)
+        
+        let memoryCache = KingfisherManager.shared.cache.memoryStorage
+        memoryCache.config.expiration = .seconds(3600)
+        
+        self.kf.setImage(with: resource)
+    }
+}

--- a/Segno/Segno/Extension/UIImageView+.swift
+++ b/Segno/Segno/Extension/UIImageView+.swift
@@ -10,9 +10,19 @@ import UIKit
 import Kingfisher
 
 extension UIImageView {
-    func setImage(from imagePath: String) {
+    func setImage(imagePath: String) {
         guard let imageURL = BaseURL.getImageURL(imagePath: imagePath) else { return }
         let resource = ImageResource(downloadURL: imageURL, cacheKey: imagePath)
+        
+        let memoryCache = KingfisherManager.shared.cache.memoryStorage
+        memoryCache.config.expiration = .seconds(3600)
+        
+        self.kf.setImage(with: resource)
+    }
+    
+    func setImage(urlString: String) {
+        guard let imageURL = URL(string: urlString) else { return }
+        let resource = ImageResource(downloadURL: imageURL, cacheKey: urlString)
         
         let memoryCache = KingfisherManager.shared.cache.memoryStorage
         memoryCache.config.expiration = .seconds(3600)

--- a/Segno/Segno/Presentation/View/DiaryCell.swift
+++ b/Segno/Segno/Presentation/View/DiaryCell.swift
@@ -70,10 +70,6 @@ final class DiaryCell: UICollectionViewCell {
     }
     
     func configure(with model: DiaryListItem) {
-        // TODO: 추후에 서버에서 path 받아오면 실행해주기
-//        if let path = model.imagePath {
-//            posterImageView.load(from: path)
-//        }
         titleLabel.text = model.title
         let imageURL = BaseURL.getImageURL(imagePath: model.thumbnailPath)
         thumbnailImageView.kf.setImage(with: imageURL)

--- a/Segno/Segno/Presentation/View/DiaryCell.swift
+++ b/Segno/Segno/Presentation/View/DiaryCell.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-import Kingfisher
-
 final class DiaryCell: UICollectionViewCell {
     private enum Metric {
         static let labelFontSize: CGFloat = 20
@@ -71,7 +69,6 @@ final class DiaryCell: UICollectionViewCell {
     
     func configure(with model: DiaryListItem) {
         titleLabel.text = model.title
-        let imageURL = BaseURL.getImageURL(imagePath: model.thumbnailPath)
-        thumbnailImageView.kf.setImage(with: imageURL)
+        thumbnailImageView.setImage(imagePath: model.thumbnailPath)
     }
 }

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -21,6 +21,7 @@ final class LocationContentView: UIView {
         static let fontSize: CGFloat = 16
         static let spacing: CGFloat = 10
         static let mapButtonSize: CGFloat = 30
+        static let mapButtonCornerRadius = mapButtonSize / 2
         static let titleText: String = "위치"
     }
     
@@ -37,14 +38,17 @@ final class LocationContentView: UIView {
     
     lazy var locationLabel: UILabel = {
         let label = UILabel()
+        label.adjustsFontSizeToFitWidth = true
         label.font = .appFont(.surroundAir, size: Metric.fontSize)
         return label
     }()
     
     private lazy var mapButton: UIButton = {
         let button = UIButton()
+        button.backgroundColor = .appColor(.color4)
+        button.layer.cornerRadius = Metric.mapButtonCornerRadius
         button.setImage(UIImage(systemName: "map.fill"), for: .normal)
-        button.tintColor = .appColor(.black)
+        button.tintColor = .appColor(.white)
         button.rx.tap
             .bind { [weak self] in
                 debugPrint("===>", self?.location)
@@ -78,7 +82,10 @@ final class LocationContentView: UIView {
         
         locationLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(titleLabel.snp.trailing).offset(Metric.spacing)
+            $0.leading.equalTo(titleLabel.snp.trailing)
+                .offset(Metric.spacing)
+            $0.trailing.equalTo(mapButton.snp.leading)
+                .offset(-Metric.spacing)
         }
         
         mapButton.snp.makeConstraints {

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-import Kingfisher
 import RxSwift
 import SnapKit
 
@@ -102,7 +101,7 @@ final class MusicContentView: UIView {
         titleLabel.text = info.title
         artistLabel.text = info.artist
         guard let imageURL = info.imageURL else { return }
-        albumArtImageView.kf.setImage(with: URL(string: imageURL))
+        albumArtImageView.setImage(urlString: imageURL)
     }
     
     func activatePlayButton(isReady status: Bool) {

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import MarqueeLabel
 import RxSwift
 import SnapKit
 
@@ -21,6 +22,7 @@ final class MusicContentView: UIView {
         static let albumArtImageViewSize: CGFloat = 30
         static let albumArtCornerRadius: CGFloat = 5
         static let playButtonSize: CGFloat = 30
+        static let playButtonCornerRadius = playButtonSize / 2
         static let playImage = UIImage(systemName: "play.fill")
         static let pauseImage = UIImage(systemName: "pause.fill")
     }
@@ -35,20 +37,16 @@ final class MusicContentView: UIView {
         return imageView
     }()
     
-    private lazy var titleLabel: UILabel = {
-        let label = UILabel()
+    private lazy var musicInfoLabel: MarqueeLabel = {
+        let label = MarqueeLabel(frame: .zero, rate: 32, fadeLength: 32.0)
         label.font = .appFont(.surround, size: Metric.fontSize)
-        return label
-    }()
-    
-    private lazy var artistLabel: UILabel = {
-        let label = UILabel()
-        label.font = .appFont(.surroundAir, size: Metric.fontSize)
         return label
     }()
     
     private lazy var playButton: UIButton = {
         let button = UIButton()
+        button.backgroundColor = .appColor(.color3)
+        button.layer.cornerRadius = Metric.playButtonCornerRadius
         button.setImage(Metric.playImage, for: .normal)
         button.tintColor = .appColor(.black)
         button.rx.tap
@@ -70,7 +68,7 @@ final class MusicContentView: UIView {
     }
     
     private func setLayout() {
-        [albumArtImageView, titleLabel, artistLabel, playButton].forEach {
+        [albumArtImageView, musicInfoLabel, playButton].forEach {
             addSubview($0)
         }
         
@@ -80,14 +78,12 @@ final class MusicContentView: UIView {
             $0.leading.equalTo(Metric.spacing)
         }
         
-        titleLabel.snp.makeConstraints {
+        musicInfoLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(albumArtImageView.snp.trailing).offset(Metric.spacing)
-        }
-        
-        artistLabel.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.leading.equalTo(titleLabel.snp.trailing).offset(Metric.spacing)
+            $0.leading.equalTo(albumArtImageView.snp.trailing)
+                .offset(Metric.spacing)
+            $0.trailing.equalTo(playButton.snp.leading)
+                .offset(-Metric.spacing)
         }
         
         playButton.snp.makeConstraints {
@@ -98,8 +94,7 @@ final class MusicContentView: UIView {
     }
     
     func setMusic(info: MusicInfo) {
-        titleLabel.text = info.title
-        artistLabel.text = info.artist
+        musicInfoLabel.text = "\(info.artist) - \(info.title)  "
         guard let imageURL = info.imageURL else { return }
         albumArtImageView.setImage(urlString: imageURL)
     }

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -45,10 +45,10 @@ final class MusicContentView: UIView {
     
     private lazy var playButton: UIButton = {
         let button = UIButton()
-        button.backgroundColor = .appColor(.color3)
+        button.backgroundColor = .appColor(.color4)
         button.layer.cornerRadius = Metric.playButtonCornerRadius
         button.setImage(Metric.playImage, for: .normal)
-        button.tintColor = .appColor(.black)
+        button.tintColor = .appColor(.white)
         button.rx.tap
             .bind { [weak self] in
                 self?.delegate?.playButtonTapped()

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 import MarqueeLabel
-import Kingfisher
 import RxCocoa
 import RxSwift
 import SnapKit
@@ -208,8 +207,7 @@ final class DiaryDetailViewController: UIViewController {
         viewModel.imagePathObservable
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] imagePath in
-                let imageURL = BaseURL.getImageURL(imagePath: imagePath)
-                self?.imageView.kf.setImage(with: imageURL)
+                self?.imageView.setImage(imagePath: imagePath)
             })
             .disposed(by: disposeBag)
         
@@ -333,7 +331,6 @@ extension UIViewController {
 
 #if canImport(SwiftUI) && DEBUG
 import SwiftUI
-import Kingfisher
 
 struct DiaryDetailViewController_Preview: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
12/11

## 작업한 내용
### Kingfisher 캐시 정책을 점검하고 적용했습니다.
- 이 과정에서 통일된 프로세스를 따르도록, 이미지 세팅 메서드를 extension으로 따로 분리했습니다.
### 상세 뷰의 음악 레이블, 위치 레이블이 너무 길 경우 화면을 벗어나는 현상을 수정했습니다.
- MarqueeLabel을 음악 쪽에 사용했고, 주소 쪽은 길면 자동으로 줄어들게끔 했습니다.
- 이 과정에서 버튼의 시인성을 포인트 컬러를 활용해 강화했습니다.

## 고민한 점 및 어려웠던 점
### 버튼이 너무 작아 누르기 어렵지는 않을지 고민됩니다.
- 30인 걸로 아는데, 조금 불편하기는 할 것 같습니다.
- 스택 뷰 기반으로 컨텐츠 뷰 UI 요소들을 리팩토링하는 게 나을까요?