### PR TITLE
레이아웃 수정

### DIFF
--- a/Segno/Segno/Extension/UIColor+.swift
+++ b/Segno/Segno/Extension/UIColor+.swift
@@ -19,6 +19,7 @@ enum SColor: String {
     case grey2
     case grey3
     case black
+    case label
 }
 
 extension UIColor {

--- a/Segno/Segno/Presentation/View/DiaryCell.swift
+++ b/Segno/Segno/Presentation/View/DiaryCell.swift
@@ -25,7 +25,7 @@ final class DiaryCell: UICollectionViewCell {
         label.adjustsFontSizeToFitWidth = true
         label.font = .appFont(.shiningStar, size: Metric.labelFontSize)
         label.textAlignment = .center
-        label.textColor = .appColor(.black)
+        label.textColor = .appColor(.label)
         return label
     }()
     

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -44,7 +44,7 @@ final class LocationContentView: UIView {
     private lazy var mapButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "map.fill"), for: .normal)
-        button.tintColor = .appColor(.black)
+        button.tintColor = .appColor(.label)
         button.rx.tap
             .bind { [weak self] in
                 debugPrint("===>", self?.location)

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -51,7 +51,7 @@ final class MusicContentView: UIView {
     private lazy var playButton: UIButton = {
         let button = UIButton()
         button.setImage(Metric.playImage, for: .normal)
-        button.tintColor = .appColor(.black)
+        button.tintColor = .appColor(.label)
         button.rx.tap
             .bind { [weak self] in
                 self?.delegate?.playButtonTapped()

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -31,7 +31,7 @@ final class MusicContentView: UIView {
     
     private lazy var albumArtImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.backgroundColor = .systemMint
+        imageView.backgroundColor = .appColor(.grey2)
         imageView.layer.cornerRadius = Metric.albumArtCornerRadius
         return imageView
     }()

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -105,7 +105,8 @@ final class DiaryCollectionViewController: UIViewController {
         title = "일기 리스트"
         navigationController?.navigationBar.titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.appFont(.surround, size: Metric.navigationTitleSize),
-            NSAttributedString.Key.foregroundColor: UIColor.appColor(.color4) ?? .red]
+            NSAttributedString.Key.foregroundColor: UIColor.appColor(.color4) ?? .red
+        ]
         
         let backBarButtonItem = UIBarButtonItem(title: "리스트", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = UIColor.appColor(.color4)

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -86,7 +86,7 @@ final class DiaryDetailViewController: UIViewController {
         textView.backgroundColor = .appColor(.grey1)
         textView.text = Metric.textViewPlaceHolder
         textView.font = .appFont(.shiningStar, size: Metric.textViewFontSize)
-        textView.textColor = .appColor(.black)
+        textView.textColor = .appColor(.label)
         textView.isEditable = false
         textView.textContainerInset = UIEdgeInsets(top: Metric.textViewInset, left: Metric.textViewInset, bottom: Metric.textViewInset, right: Metric.textViewInset)
         return textView

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -80,6 +80,7 @@ final class DiaryDetailViewController: UIViewController {
         let imageView = UIImageView()
         imageView.backgroundColor = .appColor(.color3)
         imageView.layer.cornerRadius = Metric.standardCornerRadius
+        imageView.clipsToBounds = true
         return imageView
     }()
     

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -30,6 +30,7 @@ final class DiaryDetailViewController: UIViewController {
         static let tagScrollViewHeight: CGFloat = 30
         static let musicContentViewHeight: CGFloat = 30
         static let locationContentViewHeight: CGFloat = 30
+        static let standardCornerRadius: CGFloat = 8
     }
     
     private let disposeBag = DisposeBag()
@@ -78,6 +79,7 @@ final class DiaryDetailViewController: UIViewController {
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .appColor(.color3)
+        imageView.layer.cornerRadius = Metric.standardCornerRadius
         return imageView
     }()
     
@@ -87,6 +89,7 @@ final class DiaryDetailViewController: UIViewController {
         textView.text = Metric.textViewPlaceHolder
         textView.font = .appFont(.shiningStar, size: Metric.textViewFontSize)
         textView.textColor = .appColor(.label)
+        textView.layer.cornerRadius = Metric.standardCornerRadius
         textView.isEditable = false
         textView.textContainerInset = UIEdgeInsets(top: Metric.textViewInset, left: Metric.textViewInset, bottom: Metric.textViewInset, right: Metric.textViewInset)
         return textView

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -21,6 +21,7 @@ final class DiaryEditViewController: UIViewController {
         
         // 스택 뷰 안에 들어가는 컨텐츠 설정
         static let majorContentHeight: CGFloat = 400
+        static let bodyContentHeight: CGFloat = 200
         static let minorContentHeight: CGFloat = 60
         static let semiMinorContentHeight: CGFloat = 40
         static let halfMinorContentHeight: CGFloat = 30
@@ -273,7 +274,7 @@ final class DiaryEditViewController: UIViewController {
         
         contentsStackView.addArrangedSubview(bodyTextView)
         bodyTextView.snp.makeConstraints {
-            $0.height.equalTo(Metric.majorContentHeight)
+            $0.height.equalTo(Metric.bodyContentHeight)
         }
         
         contentsStackView.addArrangedSubview(tagTextField)

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -97,8 +97,6 @@ final class DiaryEditViewController: UIViewController {
         textView.font = .appFont(.shiningStar, size: Metric.mediumFontSize)
         textView.text = Metric.bodyPlaceholder
         textView.textColor = .appColor(.grey3)
-        textView.layer.borderColor = UIColor.appColor(.color4)?.cgColor
-        textView.layer.borderWidth = 1
         textView.layer.cornerRadius = Metric.standardCornerRadius
         textView.textContainerInset = .init(top: Metric.padding, left: Metric.padding, bottom: Metric.padding, right: Metric.padding)
         textView.delegate = self

--- a/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
@@ -40,11 +40,13 @@ final class MyPageViewController: UIViewController {
     
     private enum Metric {
         static let titleText: String = "안녕하세요,\nboostcamp님!"
-        
+        static let mypageText: String = "마이페이지"
         static let settingsOffset: CGFloat = 100
         static let titleFontSize: CGFloat = 32
         static let titleOffset: CGFloat = 30
         static let separatorInset: CGFloat = 15
+        static let navigationTitleSize: CGFloat = 20
+        static let navigationBackButtonTitleSize: CGFloat = 16
     }
     
     private lazy var titleLabel: UILabel = {
@@ -94,6 +96,17 @@ final class MyPageViewController: UIViewController {
 
     private func setupView() {
         view.backgroundColor = .appColor(.background)
+        
+        navigationController?.navigationBar.titleTextAttributes = [
+            NSAttributedString.Key.font: UIFont.appFont(.surround, size: Metric.navigationTitleSize),
+            NSAttributedString.Key.foregroundColor: UIColor.appColor(.color4) ?? .red
+        ]
+        
+        let backBarButtonItem = UIBarButtonItem(title: Metric.mypageText, style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = UIColor.appColor(.color4)
+        backBarButtonItem.setTitleTextAttributes([
+            NSAttributedString.Key.font: UIFont.appFont(.surroundAir, size: Metric.navigationBackButtonTitleSize)], for: .normal)
+        navigationItem.backBarButtonItem = backBarButtonItem
     }
     
     private func setupLayout() {

--- a/Segno/Segno/Resource/Assets.xcassets/color2.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/color2.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
-          "alpha" : "0.500",
-          "blue" : "0.831",
-          "green" : "0.961",
-          "red" : "0.996"
+          "alpha" : "1.000",
+          "blue" : "0.134",
+          "green" : "0.200",
+          "red" : "0.230"
         }
       },
       "idiom" : "universal"

--- a/Segno/Segno/Resource/Assets.xcassets/color2.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/color2.colorset/Contents.json
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
+          "alpha" : "0.500",
           "blue" : "0.831",
           "green" : "0.961",
           "red" : "0.996"

--- a/Segno/Segno/Resource/Assets.xcassets/color3.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/color3.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
-          "alpha" : "0.500",
-          "blue" : "0.784",
-          "green" : "0.686",
-          "red" : "0.686"
+          "alpha" : "1.000",
+          "blue" : "0.263",
+          "green" : "0.216",
+          "red" : "0.211"
         }
       },
       "idiom" : "universal"

--- a/Segno/Segno/Resource/Assets.xcassets/color3.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/color3.colorset/Contents.json
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
+          "alpha" : "0.500",
           "blue" : "0.784",
           "green" : "0.686",
           "red" : "0.686"

--- a/Segno/Segno/Resource/Assets.xcassets/color4.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/color4.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.686",
-          "green" : "0.494",
-          "red" : "0.435"
+          "blue" : "0.531",
+          "green" : "0.393",
+          "red" : "0.353"
         }
       },
       "idiom" : "universal"

--- a/Segno/Segno/Resource/Assets.xcassets/label.colorset/Contents.json
+++ b/Segno/Segno/Resource/Assets.xcassets/label.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
12/12

## 작업한 내용
### 다크모드 관련 작업 진행
- Label 색상 추가 및 color2, 3에 대한 다크모드 색상 부여 → 지도, 뮤직뷰의 버튼 색상 / 디테일 뷰의 텍스트뷰 텍스트 색상에 적용됩니다.
### 사소한 레이아웃들 변경했습니다.
- 작성 뷰의 텍스트뷰 사이즈를 디테일뷰의 텍스트뷰사이즈와 동일하도록 변경했습니다.(=줄였습니다)
- 작성 뷰의 텍스트뷰 테두리 삭제했습니다.
- 디테일뷰의 이미지뷰, 텍스트뷰에 cornerRadius를 부여했습니다.(작성뷰와 동일합니다)
- musicContentVIew의 이미지뷰(=앨범아트뷰) 백그라운드컬러를 grey2로 변경했습니다.
- SettingViewController의 백버튼 색상 및 타이틀을 변경했습니다.

<img width="400" alt="" src="https://user-images.githubusercontent.com/29617557/206917937-3f95f854-e4f9-427a-a85c-a77934be5526.png">


<img width="400" alt="" src="https://user-images.githubusercontent.com/29617557/206917953-05142f99-f07e-479e-99ee-ed2481e57d8a.png">


<img width="400" alt="" src="https://user-images.githubusercontent.com/29617557/206917960-f35a1e38-36d4-4ddf-bfba-d3d3a92f0bbe.png">

<img width="400" alt="" src="https://user-images.githubusercontent.com/29617557/206917984-522c4a1d-21b0-469a-9bd7-2f617e6ae4fe.png">
