### PR TITLE
일기 삭제 기능

### DIFF
--- a/Segno/Segno/Data/Network/Endpoints/DiaryDeleteEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/DiaryDeleteEndpoint.swift
@@ -25,7 +25,7 @@ enum DiaryDeleteEndpoint: Endpoint {
     var parameters: HTTPRequestParameter? {
         switch self {
         case .item(let token, let diaryId):
-            return HTTPRequestParameter.body(["token": token, "diaryId": diaryId])
+            return HTTPRequestParameter.body(["token": token, "id": diaryId])
         }
     }
 }

--- a/Segno/Segno/Data/Repository/DTO/DiaryDetailDTO.swift
+++ b/Segno/Segno/Data/Repository/DTO/DiaryDetailDTO.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct DiaryDetailDTO: Decodable {
     let id: String
+    let userId: String
     let title: String
     let tags: [String]
     let imagePath: String
@@ -17,6 +18,7 @@ struct DiaryDetailDTO: Decodable {
     let location: Location?
     
     init(id: String,
+         userId: String,
          title: String,
          tags: [String],
          imagePath: String,
@@ -24,6 +26,7 @@ struct DiaryDetailDTO: Decodable {
          musicInfo: MusicInfo? = nil,
          location: Location? = nil) {
         self.id = id
+        self.userId = userId
         self.title = title
         self.tags = tags
         self.imagePath = imagePath
@@ -34,12 +37,13 @@ struct DiaryDetailDTO: Decodable {
     
     enum CodingKeys: String, CodingKey {
         case id = "_id"
-        case title, tags, imagePath, bodyText, musicInfo, location
+        case userId, title, tags, imagePath, bodyText, musicInfo, location
     }
     
     #if DEBUG
     static let example = DiaryDetailDTO(
         id: "id",
+        userId: "userId",
         title: "title",
         tags: ["tag1", "tag2"],
         imagePath: "test.png",

--- a/Segno/Segno/Data/Repository/DiaryRepository.swift
+++ b/Segno/Segno/Data/Repository/DiaryRepository.swift
@@ -39,7 +39,6 @@ final class DiaryRepositoryImpl: DiaryRepository {
     
     func postDiary(_ newDiary: NewDiaryDetail) -> Single<NewDiaryDetailDTO> {
         let newDiaryDetailEndpoint = NewDiaryPostEndpoint.item(newDiary)
-        print("========= repository -> ", newDiary)
         
         let single = NetworkManager.shared.call(newDiaryDetailEndpoint)
             .map { try JSONDecoder().decode(NewDiaryDetailDTO.self, from: $0) }

--- a/Segno/Segno/Domain/UseCase/DiaryDetailUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/DiaryDetailUseCase.swift
@@ -9,6 +9,7 @@ import RxSwift
 
 protocol DiaryDetailUseCase {
     func getDiary(id: String) -> Single<DiaryDetail>
+    func deleteDiary(id: String) -> Completable
 }
 
 final class DiaryDetailUseCaseImpl: DiaryDetailUseCase {
@@ -30,5 +31,10 @@ final class DiaryDetailUseCaseImpl: DiaryDetailUseCase {
                                musicInfo: $0.musicInfo,
                                location: $0.location)
             }
+    }
+    
+    func deleteDiary(id: String) -> Completable {
+        return repository.deleteDiary(id: id)
+            .asCompletable()
     }
 }

--- a/Segno/Segno/Domain/UseCase/DiaryDetailUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/DiaryDetailUseCase.swift
@@ -22,6 +22,7 @@ final class DiaryDetailUseCaseImpl: DiaryDetailUseCase {
     func getDiary(id: String) -> Single<DiaryDetail> {
         return repository.getDiary(id: id).map {
             return DiaryDetail(identifier: $0.id,
+                               userId: $0.userId,
                                title: $0.title,
                                tags: $0.tags,
                                imagePath: $0.imagePath,

--- a/Segno/Segno/Entity/DiaryDetail.swift
+++ b/Segno/Segno/Entity/DiaryDetail.swift
@@ -7,6 +7,7 @@
 
 struct DiaryDetail: Encodable {
     let identifier: String
+    let userId: String
     let title: String
     let tags: [String]
     let imagePath: String
@@ -16,8 +17,9 @@ struct DiaryDetail: Encodable {
     
     var token: String?
     
-    init(identifier: String, title: String, tags: [String], imagePath: String, bodyText: String?, musicInfo: MusicInfo?, location: Location?, token: String? = nil) {
+    init(identifier: String, userId: String, title: String, tags: [String], imagePath: String, bodyText: String?, musicInfo: MusicInfo?, location: Location?, token: String? = nil) {
         self.identifier = identifier
+        self.userId = userId
         self.title = title
         self.tags = tags
         self.imagePath = imagePath
@@ -30,6 +32,7 @@ struct DiaryDetail: Encodable {
     init(_ diary: DiaryDetail, imagePath: String) {
         self.init(
             identifier: diary.identifier,
+            userId: diary.userId,
             title: diary.title,
             tags: diary.tags,
             imagePath: imagePath,
@@ -44,6 +47,7 @@ struct DiaryDetail: Encodable {
     init(_ diary: DiaryDetail, token: String) {
         self.init(
             identifier: diary.identifier,
+            userId: diary.userId,
             title: diary.title,
             tags: diary.tags,
             imagePath: diary.imagePath,
@@ -57,6 +61,6 @@ struct DiaryDetail: Encodable {
 
 #if DEBUG
 extension DiaryDetail {
-    static let dummy = DiaryDetail(identifier: "1", title: "테스트", tags: ["큿소"], imagePath: "", bodyText: "테스트", musicInfo: MusicInfo.yokohama, location: nil)
+    static let dummy = DiaryDetail(identifier: "1", userId: "아이디", title: "테스트", tags: ["큿소"], imagePath: "", bodyText: "테스트", musicInfo: MusicInfo.yokohama, location: nil)
 }
 #endif

--- a/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryCollectionViewController.swift
@@ -70,6 +70,14 @@ final class DiaryCollectionViewController: UIViewController {
         return label
     }()
     
+    private lazy var backBarButtonItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(title: "리스트", style: .plain, target: self, action: nil)
+        item.tintColor = UIColor.appColor(.color4)
+        item.setTitleTextAttributes([
+            NSAttributedString.Key.font: UIFont.appFont(.surroundAir, size: Metric.navigationBackButtonTitleSize)], for: .normal)
+        return item
+    }()
+    
     init() {
         self.viewModel = DiaryCollectionViewModel()
         
@@ -107,10 +115,6 @@ final class DiaryCollectionViewController: UIViewController {
             NSAttributedString.Key.font: UIFont.appFont(.surround, size: Metric.navigationTitleSize),
             NSAttributedString.Key.foregroundColor: UIColor.appColor(.color4) ?? .red]
         
-        let backBarButtonItem = UIBarButtonItem(title: "리스트", style: .plain, target: self, action: nil)
-        backBarButtonItem.tintColor = UIColor.appColor(.color4)
-        backBarButtonItem.setTitleTextAttributes([
-            NSAttributedString.Key.font: UIFont.appFont(.surroundAir, size: Metric.navigationBackButtonTitleSize)], for: .normal)
         navigationItem.backBarButtonItem = backBarButtonItem
         
         searchBar.delegate = self

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -54,6 +54,8 @@ final class DiaryDetailViewController: UIViewController {
         return label
     }()
     
+    private lazy var userId: String = ""
+    
     private lazy var titleLabel: MarqueeLabel = {
         let label = MarqueeLabel(frame: .zero, rate: 32, fadeLength: 32.0)
         label.font = .appFont(.surround, size: Metric.titleFontSize)
@@ -131,8 +133,9 @@ final class DiaryDetailViewController: UIViewController {
         
         setupView()
         setupLayout()
+        setupRx()
+        
         bindDiaryItem()
-//        viewModel.testDataInsert() // 임시 투입 메서드입니다.
         bindAddress()
     }
     
@@ -204,8 +207,24 @@ final class DiaryDetailViewController: UIViewController {
         }
     }
     
+    private func setupRx() {
+        trashBarButtonItem.rx.tap
+            .withUnretained(self)
+            .bind { _ in
+                self.trashButtonTapped()
+            }
+            .disposed(by: disposeBag)
+    }
+    
     private func bindDiaryItem() {
         dateLabel.text = "11/22 14:54"
+        
+        viewModel.userIdObservable
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] userId in
+                self?.userId = userId
+            })
+            .disposed(by: disposeBag)
         
         viewModel.titleObservable
             .observe(on: MainScheduler.instance)
@@ -255,7 +274,7 @@ final class DiaryDetailViewController: UIViewController {
         viewModel.addressSubject
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] address in
-                self?.locationContentView.locationLabel.text  = address
+                self?.locationContentView.locationLabel.text = address
             })
             .disposed(by: disposeBag)
         
@@ -301,6 +320,12 @@ final class DiaryDetailViewController: UIViewController {
     
     private func getAddress(by location: Location) {
         viewModel.getAddress(by: location)
+    }
+    
+    private func trashButtonTapped() {
+        makeCancelOKAlert(title: "해당 Segno를 삭제하시겠습니까?", message: "") { _ in
+            print(self.userId)
+        }
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -54,7 +54,8 @@ final class DiaryDetailViewController: UIViewController {
         return label
     }()
     
-    private lazy var userId: String = ""
+    private lazy var diaryId: String = ""
+    private lazy var diaryUserId: String = ""
     
     private lazy var titleLabel: MarqueeLabel = {
         let label = MarqueeLabel(frame: .zero, rate: 32, fadeLength: 32.0)
@@ -219,10 +220,17 @@ final class DiaryDetailViewController: UIViewController {
     private func bindDiaryItem() {
         dateLabel.text = "11/22 14:54"
         
+        viewModel.idObservable
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] id in
+                self?.diaryId = id
+            })
+            .disposed(by: disposeBag)
+        
         viewModel.userIdObservable
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] userId in
-                self?.userId = userId
+                self?.diaryUserId = userId
             })
             .disposed(by: disposeBag)
         
@@ -279,6 +287,7 @@ final class DiaryDetailViewController: UIViewController {
             .disposed(by: disposeBag)
         
         subscribeMusicPlayer()
+        subscribeEditSucceed()
     }
     
     private func subscribeMusicPlayer() {
@@ -314,6 +323,20 @@ final class DiaryDetailViewController: UIViewController {
             .disposed(by: disposeBag)
     }
     
+    private func subscribeEditSucceed() {
+        viewModel.isSucceed
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] result in
+                if result {
+                    self?.navigationController?.popViewController(animated: true)
+                } else {
+                    // TODO: 알럿
+                    self?.navigationController?.popViewController(animated: true)
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
     private func getDiary() {
         viewModel.getDiary()
     }
@@ -324,7 +347,7 @@ final class DiaryDetailViewController: UIViewController {
     
     private func trashButtonTapped() {
         makeCancelOKAlert(title: "해당 Segno를 삭제하시겠습니까?", message: "") { _ in
-            print(self.userId)
+            self.viewModel.deleteDiary(id: self.diaryId)
         }
     }
 }

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -104,6 +104,18 @@ final class DiaryDetailViewController: UIViewController {
         return locationContentView
     }()
     
+    private lazy var editBarButtonItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: nil)
+        item.tintColor = UIColor.appColor(.color4)
+        return item
+    }()
+    
+    private lazy var trashBarButtonItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(barButtonSystemItem: .trash, target: self, action: nil)
+        item.tintColor = UIColor.appColor(.color4)
+        return item
+    }()
+    
     init(viewModel: DiaryDetailViewModel) {
         self.viewModel = viewModel
         
@@ -117,6 +129,7 @@ final class DiaryDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setupView()
         setupLayout()
         bindDiaryItem()
 //        viewModel.testDataInsert() // 임시 투입 메서드입니다.
@@ -135,6 +148,10 @@ final class DiaryDetailViewController: UIViewController {
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
+    }
+    
+    private func setupView() {
+        navigationItem.rightBarButtonItems = [trashBarButtonItem, editBarButtonItem]
     }
     
     private func setupLayout() {

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -22,9 +22,11 @@ final class DiaryDetailViewModel {
     var isPlaying = BehaviorSubject(value: false)
     var isReady = BehaviorSubject(value: false)
     var playerErrorStatus = PublishSubject<MusicError>()
+    var isSucceed = PublishSubject<Bool>()
     
     // TODO: DiaryDetail에 date 추가
     // lazy var dateObservable = diaryItem.map { $0.date }
+    lazy var idObservable = diaryItem.map { $0.identifier }
     lazy var userIdObservable = diaryItem.map { $0.userId }
     lazy var titleObservable = diaryItem.map { $0.title }
     lazy var tagsObservable = diaryItem.map { $0.tags }
@@ -133,6 +135,18 @@ final class DiaryDetailViewModel {
     func bindAddress() {
         getAddressUseCase.addressSubject
             .bind(to: addressSubject)
+            .disposed(by: disposeBag)
+    }
+    
+    func deleteDiary(id: String) {
+        getDetailUseCase.deleteDiary(id: id)
+            .subscribe(onCompleted: { [weak self] in
+                debugPrint("delete 성공")
+                self?.isSucceed.onNext(true)
+            }, onError: { [weak self] _ in
+                debugPrint("delete 실패")
+                self?.isSucceed.onNext(false)
+            })
             .disposed(by: disposeBag)
     }
 }

--- a/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryDetailViewModel.swift
@@ -25,6 +25,7 @@ final class DiaryDetailViewModel {
     
     // TODO: DiaryDetail에 date 추가
     // lazy var dateObservable = diaryItem.map { $0.date }
+    lazy var userIdObservable = diaryItem.map { $0.userId }
     lazy var titleObservable = diaryItem.map { $0.title }
     lazy var tagsObservable = diaryItem.map { $0.tags }
     lazy var imagePathObservable = diaryItem.map { $0.imagePath }

--- a/Segno/Segno/Presentation/ViewModel/DiaryEditViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/DiaryEditViewModel.swift
@@ -141,10 +141,10 @@ final class DiaryEditViewModel {
         
         diaryEditUseCase.postDiary(newDiary)
             .subscribe(onCompleted: { [weak self] in
-                debugPrint("전송 성공, 결과")
+                debugPrint("post 성공")
                 self?.isSucceed.onNext(true)
             }, onError: { [weak self] _ in
-                debugPrint("전송 실패")
+                debugPrint("post 실패")
                 self?.isSucceed.onNext(false)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
12/11

## 작업한 내용
### 일기 삭제 기능
- 일기 상세 뷰에서 수정과 삭제 버튼을 추가하였습니다.
- 삭제 버튼을 누르면 Alert이 떠서, 다시 한번 OK를 눌러야 삭제됩니다.

## 고민한 점 및 어려웠던 점
### 권한 설정
- 수정과 삭제를 하기 앞서, 본인의 게시글인지 확인할 필요가 있습니다.
    - 본인의 글이 아니라면 애초에 수정과 삭제 버튼이 안보이게끔 할 예정입니다.
- 글을 확인하기 위하여 서버의 Login과 SignUp, Logout에 대해서 확실하게 짚고 넘어갈 필요성을 느꼈습니다.
    - 현재 서버 가이드 상에서는 `login과 동일하지만, 새로운 유저를 생성하지는 않습니다. (login은 생성)`라고 되어있는데, 반대가 아닌가 헷갈립니다.
    - 더불어 현재는 키체인에 서버에서 제공한 `A1로 시작하는 토큰`으로 모든 토큰 관련 request들을 처리합니다.
    - 이 문제를 해결하고 수정 작업도 진행해야 할 것 같습니다.
- 여기 파트는 아니지만 생각해보니 logout도 키체인만 처리하고 서버 logout은 안했다는 사실을 깨달았습니다. 이 또한 수정해야합니다.