### PR TITLE
맵뷰가 잘리지 않도록 레이아웃 방식 변경

### DIFF
--- a/Segno/Segno/Presentation/ViewController/MapViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/MapViewController.swift
@@ -16,6 +16,7 @@ class MapViewController: UIViewController {
 
     private enum Metric {
         static let topSpace: CGFloat = 30
+        static let bottomSpace: CGFloat = 80
         static let edgeSpace: CGFloat = 20
         static let mapViewHeight: CGFloat = 500
         static let titleSize: CGFloat = 40
@@ -117,11 +118,11 @@ class MapViewController: UIViewController {
         mapView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(Metric.edgeSpace)
             $0.leading.trailing.equalToSuperview().inset(Metric.edgeSpace)
-            $0.height.equalTo(Metric.mapViewHeight)
+            $0.bottom.equalTo(addressLabel.snp.top).offset(-Metric.edgeSpace)
         }
         
         addressLabel.snp.makeConstraints {
-            $0.top.equalTo(mapView.snp.bottom).offset(Metric.edgeSpace)
+            $0.bottom.equalToSuperview().inset(Metric.bottomSpace)
             $0.leading.equalToSuperview().inset(Metric.edgeSpace)
         }
     }


### PR DESCRIPTION
12/12

## 작업한 내용
### 맵뷰가 잘리지 않도록 레이아웃방식을 변경했습니다.
- 지도에 height를 주지 않고, 밑의 주소 레이블과 위의 title 레이블의 위치에 의존하여 높이가 조절됩니다.