### PR TITLE
사소한 레이아웃 수정

### DIFF
--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -605,7 +605,7 @@ extension DiaryEditViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.text == Metric.bodyPlaceholder {
             textView.text = nil
-            textView.textColor = .appColor(.black)
+            textView.textColor = .appColor(.label)
         }
     }
     

--- a/Segno/Segno/Presentation/ViewController/MapViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/MapViewController.swift
@@ -16,6 +16,7 @@ class MapViewController: UIViewController {
 
     private enum Metric {
         static let topSpace: CGFloat = 30
+        static let bottomSpace: CGFloat = 80
         static let edgeSpace: CGFloat = 20
         static let mapViewHeight: CGFloat = 500
         static let titleSize: CGFloat = 40
@@ -117,11 +118,11 @@ class MapViewController: UIViewController {
         mapView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(Metric.edgeSpace)
             $0.leading.trailing.equalToSuperview().inset(Metric.edgeSpace)
-            $0.height.equalTo(Metric.mapViewHeight)
+            $0.bottom.equalTo(addressLabel.snp.top).offset(-Metric.edgeSpace)
         }
         
         addressLabel.snp.makeConstraints {
-            $0.top.equalTo(mapView.snp.bottom).offset(Metric.edgeSpace)
+            $0.bottom.equalToSuperview().inset(Metric.bottomSpace)
             $0.leading.equalToSuperview().inset(Metric.edgeSpace)
         }
     }


### PR DESCRIPTION
12/12

## 작업한 내용
### 맵뷰가 잘리지 않도록 레이아웃 방식을 변경했습니다
- 주소 레이블을 밑에 두고 이를 기준으로 맵뷰화면의 높이를 유동적으로 설정합니다.
### 작성 뷰컨트롤러의 텍스트뷰의 텍스트 색상을 변경했습니다.
- 다크모드에 따라 변경되도록 변경했습니다.