### PR TITLE
키체인 정보가 없을 때 로그인 페이지 연결

### DIFF
--- a/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
@@ -44,6 +44,8 @@ final class MyPageViewController: UIViewController {
     }
     
     private enum Literal {
+        static let checkTitle = "로그인 정보가 없습니다."
+        static let checkMessage = "로그인 화면으로 돌아갑니다."
         static let logoutMessage = "정말 로그아웃하시겠습니까?"
         static let logoutTitle = "로그아웃"
         static let mypageText = "마이페이지"
@@ -107,6 +109,7 @@ final class MyPageViewController: UIViewController {
         
         tableView.dataSource = nil
         getUserDetail()
+        checkUserDetail()
     }
 
     // MARK: - Setup view methods
@@ -218,6 +221,17 @@ final class MyPageViewController: UIViewController {
             self?.localUtilityManager.deleteToken(key: Literal.userToken)
             self?.mypageDelegate?.logoutButtonTapped()
         }
+    }
+    
+    private func checkUserDetail() {
+        viewModel.failureObservable
+            .subscribe(onNext: { [weak self] _ in
+                self?.makeOKAlert(title: Literal.checkTitle, message: Literal.checkMessage) { [weak self] _ in
+                    self?.localUtilityManager.deleteToken(key: Literal.userToken)
+                    self?.mypageDelegate?.logoutButtonTapped()
+                }
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/Segno/Segno/Presentation/ViewModel/MyPageViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/MyPageViewModel.swift
@@ -14,6 +14,7 @@ final class MyPageViewModel {
     
     lazy var nicknameObservable = userDetailItem.map { $0.nickname }
     lazy var writtenDiaryObservable = userDetailItem.map { $0.diaryCount }
+    var failureObservable = Observable<Bool>.empty()
     
     init(useCase: UserDetailUseCase = UserDetailUseCaseImpl()) {
         self.useCase = useCase
@@ -23,8 +24,9 @@ final class MyPageViewModel {
         useCase.getUserDetail()
             .subscribe(onSuccess: { [weak self] userDetail in
                 self?.userDetailItem.onNext(userDetail)
-            }, onFailure: { error in
+            }, onFailure: { [weak self] error in
                 print(error.localizedDescription)
+                self?.failureObservable = Observable<Bool>.just(false)
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
1/8

## 작업한 내용
### 기기에 잘못된 keychain 값이 저장되어 있을 때 로그인 페이지로 이동
- 기기를 두 개 이상(ex. 시뮬레이터와 실기기)에서 접속하면 서버에는 가장 마지막에 접속한 기기를 기준으로 토큰이 저장된다.
- 즉, 다른 기기에서는 현재 서버와는 다른, 잘못된 토큰을 가지고 있는 것이다.
- 해당 경우에는 "안녕하세요, boostcamp님"과 같이 잘못된 정보가 나오고, 마이페이지 화면에서 아무것도 할 수 없다.
- 따라서 해당 경우에 로그인 페이지로 연결시켜주었다.

## 고민한 점 및 어려웠던 점
### Observable<Bool>.empty()와 .just(false)로 에러가 난 경우를 구분하였다.
- 다만 맨 처음 마이페이지에 들어간 경우에는 실행되지 않고, 다시 Segno 페이지에 들어갔다가 마이페이지로 들어가야 팝업창이 뜬다.

https://user-images.githubusercontent.com/107831192/211188871-8eaa49a0-4eb9-4de2-8106-9100a013c4cd.mp4

