### PR TITLE
회원탈퇴 기능 구현

### DIFF
--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4F1D4E36297453E800339559 /* ResignEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1D4E35297453E800339559 /* ResignEndpoint.swift */; };
+		4F1D4E382975312300339559 /* ResignUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1D4E372975312300339559 /* ResignUseCase.swift */; };
 		4F307A512939031A00FA36A0 /* MarqueeLabel in Frameworks */ = {isa = PBXBuildFile; productRef = 4F307A502939031A00FA36A0 /* MarqueeLabel */; };
 		4F317786291BE4720019BDFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F317785291BE4720019BDFC /* Assets.xcassets */; };
 		4F317789291BE4720019BDFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F317787291BE4720019BDFC /* LaunchScreen.storyboard */; };
@@ -254,6 +255,7 @@
 /* Begin PBXFileReference section */
 		4F0372D52941DBD40014131F /* MusicError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicError.swift; sourceTree = "<group>"; };
 		4F1D4E35297453E800339559 /* ResignEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignEndpoint.swift; sourceTree = "<group>"; };
+		4F1D4E372975312300339559 /* ResignUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignUseCase.swift; sourceTree = "<group>"; };
 		4F307A4529387C1100FA36A0 /* ShazamSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShazamSession.swift; sourceTree = "<group>"; };
 		4F307A472938832900FA36A0 /* MusicSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSession.swift; sourceTree = "<group>"; };
 		4F307A49293889C200FA36A0 /* SearchMusicUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMusicUseCase.swift; sourceTree = "<group>"; };
@@ -549,6 +551,7 @@
 				9825F41A29377875005F2163 /* ChangeNicknameUseCase.swift */,
 				4F51A6FC294096480039D86A /* PlayMusicUseCase.swift */,
 				98B5EF332941B85A00287405 /* ImageUseCase.swift */,
+				4F1D4E372975312300339559 /* ResignUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -961,6 +964,7 @@
 				6662A1B12949C48A0010DA2D /* UserInfoDTO.swift in Sources */,
 				6662A1B22949C48A0010DA2D /* DiaryDetailDTO.swift in Sources */,
 				6662A1B32949C48A0010DA2D /* NewDiaryDetailDTO.swift in Sources */,
+				4F1D4E382975312300339559 /* ResignUseCase.swift in Sources */,
 				6662A1B42949C48A0010DA2D /* UserLoginDTO.swift in Sources */,
 				6662A1B52949C48A0010DA2D /* UserDetailDTO.swift in Sources */,
 				6662A1B62949C48A0010DA2D /* ImageDTO.swift in Sources */,

--- a/Segno/Segno.xcodeproj/project.pbxproj
+++ b/Segno/Segno.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4F1D4E36297453E800339559 /* ResignEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1D4E35297453E800339559 /* ResignEndpoint.swift */; };
 		4F307A512939031A00FA36A0 /* MarqueeLabel in Frameworks */ = {isa = PBXBuildFile; productRef = 4F307A502939031A00FA36A0 /* MarqueeLabel */; };
 		4F317786291BE4720019BDFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F317785291BE4720019BDFC /* Assets.xcassets */; };
 		4F317789291BE4720019BDFC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F317787291BE4720019BDFC /* LaunchScreen.storyboard */; };
@@ -252,6 +253,7 @@
 
 /* Begin PBXFileReference section */
 		4F0372D52941DBD40014131F /* MusicError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicError.swift; sourceTree = "<group>"; };
+		4F1D4E35297453E800339559 /* ResignEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResignEndpoint.swift; sourceTree = "<group>"; };
 		4F307A4529387C1100FA36A0 /* ShazamSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShazamSession.swift; sourceTree = "<group>"; };
 		4F307A472938832900FA36A0 /* MusicSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSession.swift; sourceTree = "<group>"; };
 		4F307A49293889C200FA36A0 /* SearchMusicUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMusicUseCase.swift; sourceTree = "<group>"; };
@@ -559,8 +561,8 @@
 				4F5291DD293F065D00DF930A /* DiaryEditViewModel.swift */,
 				988414D829235345007C9132 /* DiaryCollectionViewModel.swift */,
 				98AE6A87294450520039A666 /* MapViewModel.swift */,
-				983AE9D72935CEE2006547BD /* SettingsViewModel.swift */,
 				66A8CF602935F44100C17F84 /* MyPageViewModel.swift */,
+				983AE9D72935CEE2006547BD /* SettingsViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -679,6 +681,7 @@
 				66A8CF6C29379A9900C17F84 /* UserDetailEndpoint.swift */,
 				791529DD29333D40005A8DDB /* ImageEndpoint.swift */,
 				9838443D29387C0A00BCCEE2 /* ChangeNicknameEndpoint.swift */,
+				4F1D4E35297453E800339559 /* ResignEndpoint.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -732,14 +735,6 @@
 		988A934429499EEB0037D91C /* SegnoTests */ = {
 			isa = PBXGroup;
 			children = (
-				6618BC272949B6830008734D /* LoginUseCaseTest.swift */,
-				6618BC292949B6930008734D /* DiaryListUseCaseTest.swift */,
-				6618BC3D2949B87A0008734D /* DiaryDetailUseCaseTest.swift */,
-				6618BC3B2949B8610008734D /* DiaryEditUseCaseTest.swift */,
-				9858D022294B29E100559040 /* LocationUseCaseTest.swift */,
-				988A9359294A22FA0037D91C /* GetAddressUseCaseTest.swift */,
-				9858D020294B0BA600559040 /* UserDetailUseCaseTest.swift */,
-				9858D028294B7B9D00559040 /* SearchMusicUseCaseTest.swift */,
 				9858D02A294CC31A00559040 /* ChangeNicknameUseCaseTest.swift */,
 				9858D02E294CD35B00559040 /* ImageUseCaseTest.swift */,
 				9858D028294B7B9D00559040 /* SearchMusicUseCaseTest.swift */,
@@ -895,6 +890,7 @@
 				6662A16B2949C48A0010DA2D /* UIView+.swift in Sources */,
 				6662A16C2949C48A0010DA2D /* UIFont+.swift in Sources */,
 				6662A16D2949C48A0010DA2D /* SHMediaItem+.swift in Sources */,
+				4F1D4E36297453E800339559 /* ResignEndpoint.swift in Sources */,
 				6662A16E2949C48A0010DA2D /* UIButton+.swift in Sources */,
 				6662A16F2949C48A0010DA2D /* UIViewController+.swift in Sources */,
 				6662A1702949C48A0010DA2D /* UIImageView+.swift in Sources */,

--- a/Segno/Segno/Data/Network/Endpoints/ResignEndpoint.swift
+++ b/Segno/Segno/Data/Network/Endpoints/ResignEndpoint.swift
@@ -1,0 +1,32 @@
+//
+//  ResignEndpoint.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2023/01/16.
+//
+
+import Foundation
+
+enum ResignEndpoint: Endpoint {
+    case resign(String)
+    
+    var baseURL: URL? {
+        return URL(string: BaseURL.urlString)?
+            .appendingPathComponent("auth")
+    }
+    
+    var httpMethod: HTTPMethod {
+        return .POST
+    }
+    
+    var path: String {
+        return "withdrawal"
+    }
+    
+    var parameters: HTTPRequestParameter? {
+        switch self {
+        case .resign(let token):
+            return HTTPRequestParameter.body(["token": token])
+        }
+    }
+}

--- a/Segno/Segno/Data/Repository/LoginRepository.swift
+++ b/Segno/Segno/Data/Repository/LoginRepository.swift
@@ -12,6 +12,7 @@ import RxSwift
 protocol LoginRepository {
     func sendLoginRequest(withApple email: String) -> Single<UserLoginDTO>
     func sendLogoutRequest()
+    func sendResignRequest(token: String) -> Completable
 }
 
 final class LoginRepositoryImpl: LoginRepository {
@@ -26,5 +27,11 @@ final class LoginRepositoryImpl: LoginRepository {
     
     func sendLogoutRequest() {
         // TODO: Logout
+    }
+    
+    func sendResignRequest(token: String) -> Completable {
+        let endpoint = ResignEndpoint.resign(token)
+        return NetworkManager.shared.call(endpoint)
+            .asCompletable()
     }
 }

--- a/Segno/Segno/Data/Session/LoginSession.swift
+++ b/Segno/Segno/Data/Session/LoginSession.swift
@@ -16,6 +16,7 @@ final class LoginSession: NSObject {
         static let errorMessage: String = "다시 시도해주세요."
         static let parsingErrorMessage: String = "파싱 오류"
     }
+    
     private let presenter: LoginViewController
     var authorizationController: ASAuthorizationController?
     var appleEmail = PublishSubject<String>()

--- a/Segno/Segno/Domain/UseCase/ResignUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/ResignUseCase.swift
@@ -12,7 +12,7 @@ protocol ResignUseCase {
 }
 
 final class ResignUseCaseImpl: ResignUseCase {
-    private enum Metric {
+    private enum Literal {
         static let userToken = "userToken"
     }
     
@@ -26,7 +26,7 @@ final class ResignUseCaseImpl: ResignUseCase {
     }
     
     func sendResignRequest() -> Completable {
-        let token = localUtilityManager.getToken(key: Metric.userToken)
+        let token = localUtilityManager.getToken(key: Literal.userToken)
         return repository.sendResignRequest(token: token)
     }
 }

--- a/Segno/Segno/Domain/UseCase/ResignUseCase.swift
+++ b/Segno/Segno/Domain/UseCase/ResignUseCase.swift
@@ -1,0 +1,32 @@
+//
+//  ResignUseCase.swift
+//  Segno
+//
+//  Created by Gordon Choi on 2023/01/16.
+//
+
+import RxSwift
+
+protocol ResignUseCase {
+    func sendResignRequest() -> Completable
+}
+
+final class ResignUseCaseImpl: ResignUseCase {
+    private enum Metric {
+        static let userToken = "userToken"
+    }
+    
+    private let repository: LoginRepository
+    private let localUtilityManager: LocalUtilityManager
+    
+    init(repository: LoginRepository = LoginRepositoryImpl(),
+         localUtilityManager: LocalUtilityManager = LocalUtilityManagerImpl()) {
+        self.repository = repository
+        self.localUtilityManager = localUtilityManager
+    }
+    
+    func sendResignRequest() -> Completable {
+        let token = localUtilityManager.getToken(key: Metric.userToken)
+        return repository.sendResignRequest(token: token)
+    }
+}

--- a/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
@@ -48,6 +48,10 @@ final class MyPageViewController: UIViewController {
     private enum Literal {
         static let logoutMessage = "정말 로그아웃하시겠습니까?"
         static let logoutTitle = "로그아웃"
+        static let resignMessage = "정말 탈퇴하시겠습니까? 지금까지 작성한 글들이 모두 삭제됩니다."
+        static let resignTitle = "회원 탈퇴"
+        static let confirmResignMessage = "이용해 주셔서 감사합니다."
+        static let confirmResignTitle = "회원 탈퇴 완료"
         static let mypageText = "마이페이지"
         static let titleText = "안녕하세요,\nboostcamp님!"
         static let userToken = "userToken"
@@ -233,8 +237,18 @@ final class MyPageViewController: UIViewController {
     }
     
     private func resignButtonTapped() {
-        // TODO: 회원탈퇴 로직 구현
-        debugPrint("회원탈퇴")
+        makeCancelOKAlert(title: Literal.resignTitle, message: Literal.resignMessage) { [weak self] _ in
+            self?.performResign()
+        }
+    }
+    
+    private func performResign() {
+        viewModel.resign()
+        makeOKAlert(title: Literal.confirmResignTitle, message: Literal.confirmResignMessage) { [weak self] _ in
+            // TODO: 로그아웃에 쓰이는 과정을 하나의 메서드로 빼기
+            self?.localUtilityManager.deleteToken(key: Literal.userToken)
+            self?.mypageDelegate?.logoutButtonTapped()
+        }
     }
 }
 

--- a/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/MyPageViewController.swift
@@ -15,6 +15,7 @@ enum MyPageCellActions: Int {
     case diary
     case setting
     case logout
+    case resign
     
     var toRow: Int {
         return self.rawValue
@@ -25,6 +26,7 @@ enum MyPageCellModel {
     case writtenDiary(title: String, subtitle: String)
     case settings(title: String)
     case logout(title: String, color: UIColor)
+    case resign(title: String, color: UIColor)
 }
 
 protocol MyPageViewDelegate: AnyObject {
@@ -52,6 +54,7 @@ final class MyPageViewController: UIViewController {
         static let writtenDiaryCellIdentifier = "writtenDiary"
         static let settingsCellIdentifier = "settings"
         static let logoutCellIdentifier = "logout"
+        static let resignCellIdentifier = "resign"
     }
     
     // MARK: - Properties
@@ -76,6 +79,7 @@ final class MyPageViewController: UIViewController {
         tableView.register(SettingsActionSheetCell.self, forCellReuseIdentifier: Literal.writtenDiaryCellIdentifier)
         tableView.register(SettingsActionSheetCell.self, forCellReuseIdentifier: Literal.settingsCellIdentifier)
         tableView.register(SettingsActionSheetCell.self, forCellReuseIdentifier: Literal.logoutCellIdentifier)
+        tableView.register(SettingsActionSheetCell.self, forCellReuseIdentifier: Literal.resignCellIdentifier)
         tableView.separatorInset = UIEdgeInsets(top: 0, left: Metric.separatorInset, bottom: 0, right: Metric.separatorInset)
         return tableView
     }()
@@ -162,7 +166,8 @@ final class MyPageViewController: UIViewController {
                 _ = Observable<[MyPageCellModel]>.just([
                     .writtenDiary(title: "작성한 일기 수", subtitle: result),
                     .settings(title: "설정"),
-                    .logout(title: "logout", color: .red)
+                    .logout(title: "logout", color: .red),
+                    .resign(title: "회원탈퇴", color: .red)
                 ])
                     .bind(to: (self?.tableView.rx.items)!) { (tableView, row, element) in
                         switch element {
@@ -181,6 +186,11 @@ final class MyPageViewController: UIViewController {
                                     as? SettingsActionSheetCell else { return UITableViewCell() }
                             cell.configure(center: title, color: color)
                             return cell
+                        case .resign(let title, let color):
+                            guard let cell = tableView.dequeueReusableCell(withIdentifier: Literal.resignCellIdentifier)
+                                    as? SettingsActionSheetCell else { return UITableViewCell() }
+                            cell.configure(center: title, color: color)
+                            return cell
                         }
                     }
                     .disposed(by: self?.disposeBag ?? DisposeBag())
@@ -196,6 +206,8 @@ final class MyPageViewController: UIViewController {
                     self?.settingButtonTapped()
                 case .logout:
                     self?.logoutButtonTapped()
+                case .resign:
+                    self?.resignButtonTapped()
                 default:
                     break
                 }
@@ -218,6 +230,11 @@ final class MyPageViewController: UIViewController {
             self?.localUtilityManager.deleteToken(key: Literal.userToken)
             self?.mypageDelegate?.logoutButtonTapped()
         }
+    }
+    
+    private func resignButtonTapped() {
+        // TODO: 회원탈퇴 로직 구현
+        debugPrint("회원탈퇴")
     }
 }
 

--- a/Segno/Segno/Presentation/ViewModel/MyPageViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/MyPageViewModel.swift
@@ -35,8 +35,9 @@ final class MyPageViewModel {
     func resign() {
         resignUseCase.sendResignRequest()
             .subscribe(onCompleted: {
-                
+                // 탈퇴시 수행할 액션?
             }, onError: { [weak self] error in
+                // 탈퇴 과정에서 에러가 났을 경우?
                 debugPrint(error.localizedDescription)
             })
             .disposed(by: disposeBag)

--- a/Segno/Segno/Presentation/ViewModel/MyPageViewModel.swift
+++ b/Segno/Segno/Presentation/ViewModel/MyPageViewModel.swift
@@ -8,23 +8,36 @@
 import RxSwift
 
 final class MyPageViewModel {
-    private let useCase: UserDetailUseCase
+    private let userDetailUseCase: UserDetailUseCase
+    private let resignUseCase: ResignUseCase
     private var disposeBag = DisposeBag()
     private var userDetailItem = PublishSubject<UserDetailItem>()
     
     lazy var nicknameObservable = userDetailItem.map { $0.nickname }
     lazy var writtenDiaryObservable = userDetailItem.map { $0.diaryCount }
     
-    init(useCase: UserDetailUseCase = UserDetailUseCaseImpl()) {
-        self.useCase = useCase
+    init(userDetailUseCase: UserDetailUseCase = UserDetailUseCaseImpl(),
+         resignUseCase: ResignUseCase = ResignUseCaseImpl()) {
+        self.userDetailUseCase = userDetailUseCase
+        self.resignUseCase = resignUseCase
     }
     
     func getUserDetail() {
-        useCase.getUserDetail()
+        userDetailUseCase.getUserDetail()
             .subscribe(onSuccess: { [weak self] userDetail in
                 self?.userDetailItem.onNext(userDetail)
             }, onFailure: { error in
                 print(error.localizedDescription)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func resign() {
+        resignUseCase.sendResignRequest()
+            .subscribe(onCompleted: {
+                
+            }, onError: { [weak self] error in
+                debugPrint(error.localizedDescription)
             })
             .disposed(by: disposeBag)
     }

--- a/Segno/SegnoTests/LoginUseCaseTest.swift
+++ b/Segno/SegnoTests/LoginUseCaseTest.swift
@@ -25,6 +25,12 @@ final class LoginUseCaseTest: XCTestCase {
         func sendLogoutRequest() {
             
         }
+        
+        func sendResignRequest(token: String) -> Completable {
+            return Completable.create { completable in
+                return Disposables.create()
+            }
+        }
     }
     
     var scheduler: TestScheduler!


### PR DESCRIPTION
1/16

## 작업한 내용
### 자체 회원탈퇴 API에 요청을 보내는 코드를 작성했습니다.
- UserDefault에 있는 토큰을 활용해 요청을 보내게 됩니다.

## 고민한 점 및 어려웠던 점
### 탈퇴 이후 UserDefault에 있는 토큰의 처리에 관해 고민했습니다.
- 로그아웃과 동일한 과정을 로컬 내부적으로 거치게 됩니다.
- 로그아웃 기능과 머지된 다음에 구현을 이어나갈 수 있을 것 같습니다. 따라서, 구체적인 테스트도 그 이후에 이루어지게 됩니다.
### 관심사별 코드의 분리에 대해 다시 고민했습니다. 
- 지금은 로그인, 로그아웃, 회원탈퇴 코드가 약간 엉켜 있습니다.
- 각 기능의 코드를 다시 살펴보고, 필요한 부분을 분리하거나 이름을 다시 지어주는 것이 필요해 보입니다.
### 이외에 혹시 구현되지 않았을 부분이 있나? 에 대한 고민
- 일정에 쫓겨서.. 미흡한 부분이 있을 수 있습니다.
