### PR TITLE
일기 화면의 UI&UX 수정

### DIFF
--- a/Segno/Segno/Extension/UIButton+.swift
+++ b/Segno/Segno/Extension/UIButton+.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import Kingfisher
+
 extension UIButton {
     func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
         UIGraphicsBeginImageContext(CGSize(width: 1.0, height: 1.0))
@@ -19,5 +21,15 @@ extension UIButton {
         UIGraphicsEndImageContext()
          
         setBackgroundImage(backgroundImage, for: state)
+    }
+    
+    func setImage(urlString: String) {
+        guard let imageURL = URL(string: urlString) else { return }
+        let resource = ImageResource(downloadURL: imageURL, cacheKey: urlString)
+        
+        let memoryCache = KingfisherManager.shared.cache.memoryStorage
+        memoryCache.config.expiration = .seconds(3600)
+        
+        kf.setImage(with: resource, for: .normal)
     }
 }

--- a/Segno/Segno/Extension/UIButton+.swift
+++ b/Segno/Segno/Extension/UIButton+.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-import Kingfisher
-
 extension UIButton {
     func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
         UIGraphicsBeginImageContext(CGSize(width: 1.0, height: 1.0))
@@ -21,15 +19,5 @@ extension UIButton {
         UIGraphicsEndImageContext()
          
         setBackgroundImage(backgroundImage, for: state)
-    }
-    
-    func setImage(urlString: String) {
-        guard let imageURL = URL(string: urlString) else { return }
-        let resource = ImageResource(downloadURL: imageURL, cacheKey: urlString)
-        
-        let memoryCache = KingfisherManager.shared.cache.memoryStorage
-        memoryCache.config.expiration = .seconds(3600)
-        
-        kf.setImage(with: resource, for: .normal)
     }
 }

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -23,11 +23,12 @@ final class LocationContentView: UIView {
         static let spacing: CGFloat = 10
         static let mapButtonSize: CGFloat = 60
         static let mapButtonCornerRadius = mapButtonSize / 2
+        static let symbolConfig = UIImage.SymbolConfiguration(pointSize: 15, weight: .bold, scale: .large)
     }
     
     private enum Literal {
         static let titleText: String = "위치"
-        static let mapImage = UIImage(systemName: "map.fill")
+        static let mapImage = UIImage(systemName: "map.fill", withConfiguration: Metric.symbolConfig)
     }
     
     // MARK: - Properties

--- a/Segno/Segno/Presentation/View/LocationContentView.swift
+++ b/Segno/Segno/Presentation/View/LocationContentView.swift
@@ -21,7 +21,7 @@ final class LocationContentView: UIView {
     private enum Metric {
         static let fontSize: CGFloat = 16
         static let spacing: CGFloat = 10
-        static let mapButtonSize: CGFloat = 30
+        static let mapButtonSize: CGFloat = 60
         static let mapButtonCornerRadius = mapButtonSize / 2
     }
     

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -20,9 +20,9 @@ final class MusicContentView: UIView {
     private enum Metric {
         static let fontSize: CGFloat = 16
         static let spacing: CGFloat = 10
-        static let albumArtImageViewSize: CGFloat = 30
+        static let albumArtImageViewSize: CGFloat = 60
         static let albumArtCornerRadius: CGFloat = 5
-        static let playButtonSize: CGFloat = 30
+        static let playButtonSize: CGFloat = 60
         static let playButtonCornerRadius = playButtonSize / 2
     }
     

--- a/Segno/Segno/Presentation/View/MusicContentView.swift
+++ b/Segno/Segno/Presentation/View/MusicContentView.swift
@@ -24,11 +24,12 @@ final class MusicContentView: UIView {
         static let albumArtCornerRadius: CGFloat = 5
         static let playButtonSize: CGFloat = 60
         static let playButtonCornerRadius = playButtonSize / 2
+        static let symbolConfig = UIImage.SymbolConfiguration(pointSize: 15, weight: .bold, scale: .large)
     }
     
     private enum Literal {
-        static let playImage = UIImage(systemName: "play.fill")
-        static let pauseImage = UIImage(systemName: "pause.fill")
+        static let playImage = UIImage(systemName: "play.fill", withConfiguration: Metric.symbolConfig)
+        static let pauseImage = UIImage(systemName: "pause.fill", withConfiguration: Metric.symbolConfig)
     }
     
     // MARK: - Properties

--- a/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryDetailViewController.swift
@@ -29,8 +29,8 @@ final class DiaryDetailViewController: UIViewController {
         static let textViewHeight: CGFloat = 200
         static let textViewInset: CGFloat = 16
         static let tagScrollViewHeight: CGFloat = 30
-        static let musicContentViewHeight: CGFloat = 30
-        static let locationContentViewHeight: CGFloat = 30
+        static let musicContentViewHeight: CGFloat = 60
+        static let locationContentViewHeight: CGFloat = 60
         static let standardCornerRadius: CGFloat = 8
     }
     

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -39,6 +39,7 @@ final class DiaryEditViewController: UIViewController {
         static let buttonCornerRadius = CGFloat(minorContentHeight / 2)
         static let halfMinorCornerRadius = CGFloat(halfMinorContentHeight / 2)
         static let semiMinorCornerRadius = CGFloat(semiMinorContentHeight / 2)
+        static let symbolConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .bold, scale: .large)
     }
     
     private enum Literal {
@@ -64,8 +65,8 @@ final class DiaryEditViewController: UIViewController {
         static let failedToSave = "저장에 실패했습니다."
         static let photoIsRequired = "사진은 필수 입력 항목입니다."
         static let imageViewStockImage = UIImage(systemName: "photo")
-        static let musicButtonImage = UIImage(systemName: "music.note")
-        static let locationButtonImage = UIImage(systemName: "location.fill")
+        static let musicButtonImage = UIImage(systemName: "music.note", withConfiguration: Metric.symbolConfig)
+        static let locationButtonImage = UIImage(systemName: "location.fill", withConfiguration: Metric.symbolConfig)
         static let dateFormat = "yyyy년 MM월 dd일 HH시 mm분에 저장된 세뇨입니다."
         static let localeIdentifier = "ko_KR"
     }

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -34,6 +34,7 @@ final class DiaryEditViewController: UIViewController {
         static let smallFontSize: CGFloat = 16
         static let textFieldFontSize: CGFloat = 12
         static let padding: CGFloat = 12
+        static let albumArtCornerRadius: CGFloat = 5
         static let leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: padding, height: 0.0))
         static let buttonCornerRadius = CGFloat(minorContentHeight / 2)
         static let halfMinorCornerRadius = CGFloat(halfMinorContentHeight / 2)
@@ -156,7 +157,6 @@ final class DiaryEditViewController: UIViewController {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.backgroundColor = .appColor(.grey1)
-        stackView.distribution = .equalSpacing
         stackView.layer.cornerRadius = Metric.buttonCornerRadius
         stackView.spacing = Metric.doubleSpacing
         stackView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: Metric.padding)
@@ -173,8 +173,16 @@ final class DiaryEditViewController: UIViewController {
         return button
     }()
     
+    private lazy var musicAlbumArt: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .appColor(.grey1)
+        imageView.layer.cornerRadius = Metric.albumArtCornerRadius
+        return imageView
+    }()
+    
     private lazy var musicInfoLabel: MarqueeLabel = {
         let label = MarqueeLabel(frame: .zero, rate: 32, fadeLength: 32.0)
+        label.textAlignment = .right
         label.font = .systemFont(ofSize: Metric.smallFontSize)
         label.text = Literal.musicPlaceholder
         label.trailingBuffer = 16.0
@@ -347,6 +355,10 @@ final class DiaryEditViewController: UIViewController {
         addMusicButton.snp.makeConstraints {
             $0.width.equalTo(Metric.minorContentHeight)
         }
+        musicStackView.addArrangedSubview(musicAlbumArt)
+        musicAlbumArt.snp.makeConstraints {
+            $0.width.equalTo(Metric.minorContentHeight)
+        }
         musicStackView.addArrangedSubview(musicInfoLabel)
     }
     
@@ -466,8 +478,6 @@ final class DiaryEditViewController: UIViewController {
             .subscribe(onNext: { [weak self] info in
                 guard let info else { return }
                 self?.musicInfoLabel.text = "\(info.artist) - \(info.title)"
-                guard let imageURL = info.imageURL else { return }
-                self?.addMusicButton.setImage(urlString: imageURL)
             })
             .disposed(by: disposeBag)
         
@@ -513,6 +523,9 @@ final class DiaryEditViewController: UIViewController {
                 debugPrint(song)
                 
                 self?.musicInfoLabel.text = "\(artist) - \(title)"
+                
+                guard let imageURL = song.imageURL else { return }
+                self?.musicAlbumArt.setImage(urlString: imageURL)
             })
             .disposed(by: disposeBag)
     }

--- a/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
+++ b/Segno/Segno/Presentation/ViewController/DiaryEditViewController.swift
@@ -466,6 +466,8 @@ final class DiaryEditViewController: UIViewController {
             .subscribe(onNext: { [weak self] info in
                 guard let info else { return }
                 self?.musicInfoLabel.text = "\(info.artist) - \(info.title)"
+                guard let imageURL = info.imageURL else { return }
+                self?.addMusicButton.setImage(urlString: imageURL)
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
2/10

## 작업한 내용
### 음악 재생 버튼과 지도 버튼 UX 개선
### 음악 검색이 완료되었을 때 앨범 아트 표시

## 고민한 점 및 어려웠던 점
### 음악 재생 버튼을 얼마나 늘릴지
- 다음은 기존, 재생버튼과 지도버튼만 늘렸을때, 앨범아트까지 늘렸을 때의 크기 비교로, 결국 앨범아트까지 늘린 코드로 PR을 올렸다.

<img src="https://user-images.githubusercontent.com/107831192/218060990-c9107537-9889-4ae3-8f42-ee8fc66311e2.png" width=30%> <img src="https://user-images.githubusercontent.com/107831192/218061065-0e7af18c-a6f9-4d8a-9675-e6a9c3cf1864.png" width=30%> <img src="https://user-images.githubusercontent.com/107831192/218061139-28288542-74e1-4d95-9790-02466389ac66.png" width=30%>

### 앨범아트를 어디에 띄워줄 것인가
- 검색 버튼 옆에 띄워주는게 제일 깔끔해서 그렇게 처리하였다.
<img src="https://user-images.githubusercontent.com/107831192/218069608-870dd576-3e75-466c-b28e-3ca4a8c192c9.png" width=30%>